### PR TITLE
Add injectable hadoop configuration to ParquetWriter.Options

### DIFF
--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
@@ -64,7 +64,8 @@ object ParquetWriter  {
                     pageSize: Int = HadoopParquetWriter.DEFAULT_PAGE_SIZE,
                     rowGroupSize: Int = HadoopParquetWriter.DEFAULT_BLOCK_SIZE,
                     validationEnabled: Boolean = HadoopParquetWriter.DEFAULT_IS_VALIDATING_ENABLED,
-                    timeZone: TimeZone = TimeZone.getDefault
+                    timeZone: TimeZone = TimeZone.getDefault,
+                    hadoopConfig: Configuration = new Configuration()
                     ) {
     private[parquet4s] def toValueCodecConfiguration: ValueCodecConfiguration = ValueCodecConfiguration(timeZone)
   }
@@ -79,6 +80,7 @@ object ParquetWriter  {
       .withPageSize(options.pageSize)
       .withRowGroupSize(options.rowGroupSize)
       .withValidation(options.validationEnabled)
+      .withConf(options.hadoopConfig)
       .build()
 
   /**


### PR DESCRIPTION
I needed to be able to update the hadoop config in order to use an `AWSCredentialsProvider` other than the default for the `s3a` filesystem.

I'm currently running with a fork of this project embedded in my application, but the (tiny) patch is here in case you want to include it upstream.