### PR TITLE
Incremental Writer

### DIFF
--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetWriterAndParquetReaderCompatibilityItSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetWriterAndParquetReaderCompatibilityItSpec.scala
@@ -17,7 +17,7 @@ class ParquetWriterAndParquetReaderCompatibilityItSpec extends
   private def runTestCase(testCase: CaseDef, incremental: Boolean = false): Unit = {
     testCase.description in {
       if (incremental) {
-        val w = ParquetWriter.incremental[testCase.DataType](tempPathString)(testCase.writer)
+        val w: IncrementalParquetWriter[testCase.DataType] = ParquetWriter.incremental(tempPathString)(testCase.writer)
         try testCase.data.foreach(d => w.write(Iterable(d)))
         finally w.close()
       } else ParquetWriter.write(tempPathString, testCase.data)(testCase.writer)

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetWriterAndParquetReaderCompatibilityItSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetWriterAndParquetReaderCompatibilityItSpec.scala
@@ -18,7 +18,8 @@ class ParquetWriterAndParquetReaderCompatibilityItSpec extends
     testCase.description in {
       if (incremental) {
         val w: IncrementalParquetWriter[testCase.DataType] = ParquetWriter.incremental(tempPathString)(testCase.writer)
-        try testCase.data.foreach(d => w.write(Iterable(d)))
+        val q = testCase.data.map(Iterable(_))
+        try testCase.data.map(Iterable(_)).foreach(w.write)
         finally w.close()
       } else ParquetWriter.write(tempPathString, testCase.data)(testCase.writer)
       val parquetIterable = ParquetReader.read(tempPathString)(testCase.reader)

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
@@ -33,16 +33,16 @@ trait ParquetWriter[T] {
   /**
     * Instantiate a new [[IncrementalParquetWriter]]
     * @param path The path to which this writer will write
-    * @param options Options for writing
+    * @param options configuration of how Parquet files should be created and written
     */
   def incrementalWriter(path: String, options: ParquetWriter.Options): IncrementalParquetWriter[T]
 
 }
 
 /**
-  * Interface for a writer which can incrementally write records of type [[T]] to the given path with the given options
+  * Interface for a writer which can incrementally write records of type [[T]] to the given path with the given options.
   * @param path The path to which this writer will write
-  * @param options Options for writing
+  * @param options configuration of how Parquet files should be created and written
   * @tparam T schema of data to write.
   */
 abstract class IncrementalParquetWriter[T] private[parquet4s] (path: String, options: ParquetWriter.Options) {

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
@@ -2,7 +2,6 @@ package com.github.mjakubowski84.parquet4s
 
 import java.util.TimeZone
 
-import com.github.mjakubowski84.parquet4s.ParquetWriter.internalWriter
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.api.WriteSupport


### PR DESCRIPTION
This is a first pass at addressing: https://github.com/mjakubowski84/parquet4s/issues/88

This implementation feels quite clunky but it's the best I could do while minimizing the amount of API change. It was particularly difficult to get it incorporated into the `ParquetWriterAndParquetReaderCompatibilityItSpec`. Specifically I had to put the actual implementation of `write` and `close` in the `implicit def writer` in order to satisfy the implicit evidence required when using `testCase.DataType` as a type parameter. I'm open to any suggestions for improving it. I've done a fair amount of scala but haven't used type-classes a lot, which seem to be used a lot in this project.

