### PR TITLE
IncrementalParquetWriter implemented as a separate trait

### DIFF
--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/IncrementalParquetWriterItSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/IncrementalParquetWriterItSpec.scala
@@ -1,0 +1,69 @@
+package com.github.mjakubowski84.parquet4s
+
+import java.nio.file.{Files, Paths}
+
+import org.apache.parquet.hadoop.ParquetFileWriter
+import org.scalatest.{BeforeAndAfter, FreeSpec, Matchers}
+
+import scala.util.Random
+
+class IncrementalParquetWriterItSpec extends FreeSpec with Matchers with BeforeAndAfter {
+
+  case class Record(i: Int, d: Double, s: String)
+  object Record {
+    def random(n: Int): Seq[Record] = (1 to n).map(_ => Record(Random.nextInt(), Random.nextDouble(), Random.nextString(10)))
+  }
+
+  private val tempDir = com.google.common.io.Files.createTempDir().toPath
+  private val batchPath = Paths.get(s"$tempDir/batch.parquet")
+  private val incrementalPath = Paths.get(s"$tempDir/incremental.parquet")
+
+  // Generate records and do a single batch write.
+  private val records = Record.random(5000)
+  ParquetWriter.write(batchPath.toString, records)
+
+  private def incrementalRecords: Seq[Record] = {
+    val iter = ParquetReader.read[Record](incrementalPath.toString)
+    try iter.toSeq finally iter.close()
+  }
+
+  after { // Delete the incremental path after writing.
+    Files.deleteIfExists(incrementalPath)
+  }
+
+  "Single incremental write produces the same result as a single batch write" in {
+    val w = IncrementalParquetWriter[Record](incrementalPath.toString)
+    try w.write(records) finally w.close()
+    incrementalRecords shouldBe records
+  }
+
+  "Multiple incremental writes produce same result as a single batch write" in {
+    val w = IncrementalParquetWriter[Record](incrementalPath.toString)
+    try records.grouped(2).foreach(w.write) finally w.close()
+    incrementalRecords shouldBe records
+  }
+
+  "Synchronized parallel writes produce same result (after sorting) as a single batch write" in {
+    val w = IncrementalParquetWriter[Record](incrementalPath.toString)
+    try records.grouped(2).toSeq.par.foreach(g => synchronized(w.write(g))) finally w.close()
+    incrementalRecords.sortBy(_.toString) shouldBe records.sortBy(_.toString)
+  }
+
+  "Incremental writes work with write mode OVERWRITE" in {
+    val w = IncrementalParquetWriter[Record](incrementalPath.toString, ParquetWriter.Options(ParquetFileWriter.Mode.OVERWRITE))
+    try records.grouped(2).foreach(w.write) finally w.close()
+    incrementalRecords shouldBe records
+  }
+
+  "Writing to closed writer throws an exception" in {
+    val w = IncrementalParquetWriter[Record](incrementalPath.toString)
+    w.close()
+    a [NullPointerException] should be thrownBy records.grouped(2).foreach(w.write)
+  }
+
+  "Closing writer without writing anything to it" in {
+    val w = IncrementalParquetWriter[Record](incrementalPath.toString)
+    noException should be thrownBy w.close()
+  }
+
+}

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/IncrementalParquetWriter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/IncrementalParquetWriter.scala
@@ -3,6 +3,7 @@ package com.github.mjakubowski84.parquet4s
 import java.io.Closeable
 
 import org.apache.hadoop.fs.Path
+import org.slf4j.LoggerFactory
 
 /**
   * Interface for a writer which can handle multiple calls to .write with a single call to .close.
@@ -20,16 +21,37 @@ object IncrementalParquetWriter {
     * @param options configuration of how Parquet files should be created and written
     * @tparam T schema of data to write
     */
-  def apply[T: ParquetRecordEncoder : ParquetSchemaResolver](path: String, options: ParquetWriter.Options = ParquetWriter.Options()): IncrementalParquetWriter[T] = {
+  def apply[T: ParquetRecordEncoder: ParquetSchemaResolver](
+      path: String,
+      options: ParquetWriter.Options = ParquetWriter.Options())
+    : IncrementalParquetWriter[T] = {
     new IncrementalParquetWriter[T] {
-      private val writer = ParquetWriter.internalWriter(new Path(path), ParquetSchemaResolver.resolveSchema[T], options)
+      private val writer = ParquetWriter.internalWriter(
+        new Path(path),
+        ParquetSchemaResolver.resolveSchema[T],
+        options)
       private val valueCodecConfiguration = options.toValueCodecConfiguration
+      private val logger = LoggerFactory.getLogger(this.getClass)
+      private var isClosed: Boolean = false
+
       override def write(data: Iterable[T]): Unit =
-        data.foreach { elem =>
-          writer.write(ParquetRecordEncoder.encode[T](elem, valueCodecConfiguration))
+        if (isClosed)
+          throw new IllegalStateException(
+            "Attempted to write with a writer which was already closed")
+        else
+          data.foreach { elem =>
+            writer.write(
+              ParquetRecordEncoder.encode[T](elem, valueCodecConfiguration))
+          }
+
+      override def close(): Unit = this.synchronized {
+        if (isClosed)
+          logger.warn("Attempted to close a writer which was already closed")
+        else {
+          isClosed = true
+          writer.close()
         }
-      override def close(): Unit = writer.close()
+      }
     }
   }
 }
-

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/IncrementalParquetWriter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/IncrementalParquetWriter.scala
@@ -1,0 +1,35 @@
+package com.github.mjakubowski84.parquet4s
+
+import java.io.Closeable
+
+import org.apache.hadoop.fs.Path
+
+/**
+  * Interface for a writer which can handle multiple calls to .write with a single call to .close.
+  * @tparam T schema of data to write
+  */
+trait IncrementalParquetWriter[T] extends Closeable {
+  def write(data: Iterable[T])
+}
+
+object IncrementalParquetWriter {
+
+  /**
+    * Default instance of an [[IncrementalParquetWriter]]
+    * @param path location where files are meant to be written
+    * @param options configuration of how Parquet files should be created and written
+    * @tparam T schema of data to write
+    */
+  def apply[T: ParquetRecordEncoder : ParquetSchemaResolver](path: String, options: ParquetWriter.Options = ParquetWriter.Options()): IncrementalParquetWriter[T] = {
+    new IncrementalParquetWriter[T] {
+      private val writer = ParquetWriter.internalWriter(new Path(path), ParquetSchemaResolver.resolveSchema[T], options)
+      private val valueCodecConfiguration = options.toValueCodecConfiguration
+      override def write(data: Iterable[T]): Unit =
+        data.foreach { elem =>
+          writer.write(ParquetRecordEncoder.encode[T](elem, valueCodecConfiguration))
+        }
+      override def close(): Unit = writer.close()
+    }
+  }
+}
+


### PR DESCRIPTION
As discussed in the latest comments from https://github.com/mjakubowski84/parquet4s/issues/88, this is an incremental writer implemented as a separate trait. Ideally in the future this would be unified with the existing type-classes but that would involve breaking changes ATM.

Only thing here that seems a bit weird to me is getting a NullPointerException when you write to a closed writer.. maybe we should maintain an internal `var isClosed: Boolean` that would let us throw a more meaningful exception?