### PR TITLE
in operator for before-read filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ ParquetStreams.fromParquet[Stats](
 )
 ```
 
-You can construct filter predicates using `===`, `!==`, `>`, `>=`, `<`, `<=` operators on columns containing primitive values. You can combine and modify predicates using `&&`, `||` and `!` operators. Mind that operations on `java.sql.Timestamp` and `java.time.LocalDateTime` are not supported as Parquet still not allows filtering by `Int96` out of the box.
+You can construct filter predicates using `===`, `!==`, `>`, `>=`, `<`, `<=`, and `in` operators on columns containing primitive values. You can combine and modify predicates using `&&`, `||` and `!` operators. `in` looks for values in a list of keys, similar to SQL's `in` operator. Mind that operations on `java.sql.Timestamp` and `java.time.LocalDateTime` are not supported as Parquet still not allows filtering by `Int96` out of the box.
 
 Check ScalaDoc and code for more!
 

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/FilteringByListSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/FilteringByListSpec.scala
@@ -125,4 +125,9 @@ class FilteringByListSpec extends FlatSpec with Matchers with BeforeAndAfterAll 
     filteredRecords.size should equal(3)
     filteredRecords.map(_.idx) should contain allOf(1, 2, 3)
   }
+
+  it should "reject an empty set of keys" in {
+    a[IllegalArgumentException] should be thrownBy (Col("idx") in())
+    a[IllegalArgumentException] should be thrownBy (Col("idx") in Set.empty[Int])
+  }
 }

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/FilteringByListSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/FilteringByListSpec.scala
@@ -1,0 +1,122 @@
+package com.github.mjakubowski84.parquet4s
+
+import java.nio.file.Paths
+import java.sql.Date
+import java.time.LocalDate
+
+import com.google.common.io.Files
+import org.apache.parquet.filter2.predicate.Operators.{Column, DoubleColumn, FloatColumn, SupportsEqNotEq}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Inspectors, Matchers}
+
+import scala.util.Random
+
+class FilteringByListSpec extends FlatSpec with Matchers with BeforeAndAfterAll with Inspectors {
+
+
+  case class Embedded(x: Int)
+
+  case class Data(
+                   idx: Int,
+                   short: Short,
+                   byte: Byte,
+                   char: Char,
+                   long: Long,
+                   float: Float,
+                   double: Double,
+                   enum: String,
+                   flag: Boolean,
+                   date: LocalDate,
+                   sqlDate: Date,
+                   decimal: BigDecimal,
+                   embedded: Embedded
+                 )
+
+  val enum: Seq[String] = List("a", "b", "c", "d")
+  val dataSize: Int = 4096
+  val halfSize: Int = dataSize / 2
+  val filePath: String = Paths.get(Files.createTempDir().getAbsolutePath, "file.parquet").toString
+  val zeroDate: LocalDate = LocalDate.of(1900, 1, 1)
+
+  implicit val localDateOrdering: Ordering[LocalDate] = new Ordering[LocalDate] {
+    override def compare(x: LocalDate, y: LocalDate): Int = x.compareTo(y)
+  }
+
+  implicit val sqlDateOrdering: Ordering[Date] = new Ordering[Date] {
+    override def compare(x: Date, y: Date): Int = x.compareTo(y)
+  }
+
+  def data: Stream[Data] =
+    Stream.range(0, dataSize).map { i =>
+      Data(
+        idx = i,
+        short = (i % Short.MaxValue).toShort,
+        byte = (i % Byte.MaxValue).toByte,
+        char = (i % Char.MaxValue).toChar,
+        long = i.toLong,
+        float = (BigDecimal("0.01") * BigDecimal(i)).toFloat,
+        double = (BigDecimal("0.00000001") * BigDecimal(i)).toDouble,
+        enum = enum(Random.nextInt(enum.size - 1)),
+        flag = Random.nextBoolean(),
+        date = zeroDate.plusDays(i),
+        sqlDate = Date.valueOf(zeroDate.plusDays(i)),
+        decimal = BigDecimal.valueOf(0.001 * (i - halfSize)),
+        embedded = Embedded(i)
+      )
+    }
+
+  def everyOtherDatum: Stream[Data] = data.filter(_.idx % 2 == 0)
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    ParquetWriter.write(filePath, data, ParquetWriter.Options(
+      rowGroupSize = 512 * 1024,
+      pageSize = 128 * 1024,
+      dictionaryPageSize = 128 * 1024
+    ))
+  }
+
+  def genericFilterTest[T: Ordering, V <: Comparable[V], C <: Column[V] with SupportsEqNotEq](columnName: String, field: Data => T)
+                                                                                             (implicit filterValueSetConverter: FilterValueSetConverter[T, V, C]): Unit = {
+    val filterValues = everyOtherDatum.map(field)
+    val actual = ParquetReader.read[Data](filePath, filter = Col(columnName) in filterValues)
+
+    actual.map(_.idx) should equal(everyOtherDatum.map(_.idx))
+  }
+
+  def specificValueFilterTest[T: Ordering, V <: Comparable[V], C <: Column[V] with SupportsEqNotEq](columnName: String, field: Data => T, values: Vector[T])
+                                                                                                   (implicit filterValueSetConverter: FilterValueSetConverter[T, V, C]): Unit = {
+    val filteredRecords = ParquetReader.read[Data](filePath, filter = Col(columnName) in values)
+    filteredRecords.map(field) should contain only (values: _*)
+
+    val manuallyFilteredRecords = ParquetReader
+      .read[Data](filePath)
+      .filter(row => values.contains(field(row)))
+
+    filteredRecords.map(_.idx) should equal(manuallyFilteredRecords.map(_.idx))
+
+  }
+
+  "Filtering" should "filter data by a list of ints" in genericFilterTest("idx", _.idx)
+
+  it should "filter data by a list of shorts" in genericFilterTest("short", _.short)
+
+  it should "filter data by a list of bytes" in specificValueFilterTest("byte", _.byte, Vector(0, 1, 2, 3).map(_.toByte))
+
+  it should "filter data by a list of chars" in genericFilterTest("char", _.char)
+
+  it should "filter data by a list of longs" in genericFilterTest("long", _.long)
+
+  it should "filter data by a list of floats" in genericFilterTest[Float, java.lang.Float, FloatColumn]("float", _.float)
+
+  it should "filter data by a list of doubles" in genericFilterTest[Double, java.lang.Double, DoubleColumn]("double", _.double)
+
+  it should "filter data by a list of strings" in specificValueFilterTest("enum", _.enum, Vector("a", "b"))
+
+  it should "filter data by a list of SQL dates" in genericFilterTest("sqlDate", _.sqlDate)
+
+  it should "filter data by a list of dates" in genericFilterTest("date", _.date)
+
+  it should "filter data by a list of decimals" in genericFilterTest("decimal", _.decimal)
+
+  it should "filter data by a list of embedded values" in genericFilterTest("embedded.x", _.idx)
+}

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/Filter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/Filter.scala
@@ -1,13 +1,11 @@
 package com.github.mjakubowski84.parquet4s
 
 import com.github.mjakubowski84.parquet4s.FilterValue.FilterValueFactory
-import com.github.mjakubowski84.parquet4s.FilterValueSet.FilterValueSetFactory
 import org.apache.parquet.filter2.compat.FilterCompat
 import org.apache.parquet.filter2.predicate.Operators._
 import org.apache.parquet.filter2.predicate.{FilterApi, FilterPredicate, Statistics, UserDefinedPredicate}
 import org.apache.parquet.io.api.Binary
 
-import scala.collection.immutable
 import scala.language.{higherKinds, implicitConversions}
 
 /**
@@ -125,13 +123,18 @@ object Filter {
     }
   }
 
-  def inFilter[V <: Comparable[V], C <: Column[V] with SupportsEqNotEq](columnPath: String, filterValueSetFactory: FilterValueSetFactory[V, C]): Filter =
+  def inFilter[V <: Comparable[V], C <: Column[V] with SupportsEqNotEq](columnPath: String, filterValueFactories: Iterable[FilterValueFactory[V, C]]): Filter = {
+    require(filterValueFactories.nonEmpty, "Cannot filter with an empty list of keys.")
+
     new Filter {
       override def toPredicate(valueCodecConfiguration: ValueCodecConfiguration): FilterPredicate = {
-        val filterValue = filterValueSetFactory(valueCodecConfiguration)
-        FilterApi.userDefined(filterValue.columnFactory(columnPath), InPredicate(filterValue.value))
+        val filterValues = filterValueFactories.map(_ (valueCodecConfiguration))
+        val column = filterValues.head.columnFactory(columnPath)
+        val valueSet = filterValues.map(_.value).toSet
+        FilterApi.userDefined(column, InPredicate(valueSet))
       }
     }
+  }
 
   val noopFilter: Filter = new Filter {
     override def toPredicate(valueCodecConfiguration: ValueCodecConfiguration): FilterPredicate = new FilterPredicate {
@@ -193,8 +196,16 @@ case class Col(columnPath: String) {
   /**
     * @return Returns [[Filter]] that passes data that, in `this` column, is <b>equal to</b> one of the provided values
     */
-  def in[V <: Comparable[V], C <: Column[V] with SupportsEqNotEq](filterValueSetFactory: FilterValueSetFactory[V, C]): Filter =
-    Filter.inFilter(columnPath, filterValueSetFactory)
+  def in[V <: Comparable[V], C <: Column[V] with SupportsEqNotEq](filterValueFactories: FilterValueFactory[V, C]*): Filter =
+    Filter.inFilter(columnPath, filterValueFactories.toSet)
+
+  /**
+    * @return Returns [[Filter]] that passes data that, in `this` column, is <b>equal to</b> one of the provided values
+    */
+  def in[In, V <: Comparable[V], C <: Column[V] with SupportsEqNotEq](in: Iterable[In])
+                                                                     (implicit conv: FilterValueConverter[In, V, C]): Filter = {
+    Filter.inFilter(columnPath, in.map(conv.convert))
+  }
 }
 
 private trait FilterValueConverter[In, V <: Comparable[V], C <: Column[V]] {
@@ -291,93 +302,3 @@ private trait FilterValue[V <: Comparable[V], C <: Column[V]] {
 private class FilterValueImpl[V <: Comparable[V], C <: Column[V]](override val value: V,
                                                                   override val columnFactory: String => C
                                                                  ) extends FilterValue[V, C]
-
-private trait FilterValueSetConverter[In, V <: Comparable[V], C <: Column[V]] {
-
-  def convert(in: Iterable[In]): FilterValueSetFactory[V, C]
-}
-
-private class SimpleFilterValueSetConverter[In, V <: Comparable[V], C <: Column[V]](f: Iterable[In] => FilterValueSet[V, C]
-                                                                                   ) extends FilterValueSetConverter[In, V, C] {
-  override def convert(in: Iterable[In]): FilterValueSetFactory[V, C] = _ => f(in)
-}
-
-private class BinaryFilterValueSetConverter[In](codec: ValueCodec[In]) extends FilterValueSetConverter[In, Binary, BinaryColumn] {
-  override def convert(in: Iterable[In]): FilterValueSetFactory[Binary, BinaryColumn] =
-    conf => FilterValueSet.binary(in.map(codec.encode(_, conf).asInstanceOf[BinaryValue].value))
-}
-
-private class IntFilterValueSetConverter[In](codec: ValueCodec[In]) extends FilterValueSetConverter[In, Integer, IntColumn] {
-  override def convert(in: Iterable[In]): FilterValueSetFactory[Integer, IntColumn] =
-    conf => FilterValueSet.int(in.map(codec.encode(_, conf).asInstanceOf[PrimitiveValue[Int]].value))
-}
-
-private object FilterValueSetConverter {
-  implicit val stringFilterValueSetConverter: FilterValueSetConverter[String, Binary, BinaryColumn] =
-    new BinaryFilterValueSetConverter(ValueCodec.stringCodec)
-
-  implicit val intFilterValueSetConverter: FilterValueSetConverter[Int, Integer, IntColumn] =
-    new SimpleFilterValueSetConverter(FilterValueSet.int)
-
-  implicit val shortFilterValueSetConverter: FilterValueSetConverter[Short, Integer, IntColumn] =
-    new SimpleFilterValueSetConverter(shorts => FilterValueSet.int(shorts.map(_.toInt)))
-
-  implicit val byteFilterValueSetConverter: FilterValueSetConverter[Byte, Integer, IntColumn] =
-    new SimpleFilterValueSetConverter(bytes => FilterValueSet.int(bytes.map(_.toInt)))
-
-  implicit val charFilterValueSetConverter: FilterValueSetConverter[Char, Integer, IntColumn] =
-    new SimpleFilterValueSetConverter(chars => FilterValueSet.int(chars.map(_.toInt)))
-
-  implicit val longFilterValueSetConverter: FilterValueSetConverter[Long, java.lang.Long, LongColumn] =
-    new SimpleFilterValueSetConverter(FilterValueSet.long)
-
-  implicit val floatFilterValueSetConverter: FilterValueSetConverter[Float, java.lang.Float, FloatColumn] =
-    new SimpleFilterValueSetConverter(FilterValueSet.float)
-
-  implicit val doubleFilterValueSetConverter: FilterValueSetConverter[Double, java.lang.Double, DoubleColumn] =
-    new SimpleFilterValueSetConverter(FilterValueSet.double)
-
-  implicit val sqlDateFilterValueSetConverter: FilterValueSetConverter[java.sql.Date, Integer, IntColumn] =
-    new IntFilterValueSetConverter(ValueCodec.sqlDateCodec)
-
-  implicit val localDateFilterValueSetConverter: FilterValueSetConverter[java.time.LocalDate, Integer, IntColumn] =
-    new IntFilterValueSetConverter(ValueCodec.localDateCodec)
-
-  implicit val decimalFilterValueSetConverter: FilterValueSetConverter[BigDecimal, Binary, BinaryColumn] =
-    new BinaryFilterValueSetConverter(ValueCodec.decimalCodec)
-
-}
-
-private object FilterValueSet {
-  type FilterValueSetFactory[V <: Comparable[V], C <: Column[V]] = ValueCodecConfiguration => FilterValueSet[V, C]
-
-  implicit def convert[In, V <: Comparable[V], C <: Column[V]](in: Iterable[In])
-                                                              (implicit filterValueSetConverter: FilterValueSetConverter[In, V, C]): FilterValueSetFactory[V, C] =
-    filterValueSetConverter.convert(in)
-
-  def binary(binaries: Iterable[Binary]): FilterValueSet[Binary, BinaryColumn] =
-    new FilterValueSetImpl(binaries.to[immutable.Set], FilterApi.binaryColumn)
-
-  def int(ints: Iterable[Int]): FilterValueSet[Integer, IntColumn] =
-    new FilterValueSetImpl(ints.map(new Integer(_)).to[immutable.Set], FilterApi.intColumn)
-
-  def long(longs: Iterable[Long]): FilterValueSet[java.lang.Long, LongColumn] =
-    new FilterValueSetImpl(longs.map(new java.lang.Long(_)).to[immutable.Set], FilterApi.longColumn)
-
-  def float(floats: Iterable[Float]): FilterValueSet[java.lang.Float, FloatColumn] =
-    new FilterValueSetImpl(floats.map(new java.lang.Float(_)).to[immutable.Set], FilterApi.floatColumn)
-
-  def double(doubles: Iterable[Double]): FilterValueSet[java.lang.Double, DoubleColumn] =
-    new FilterValueSetImpl(doubles.map(new java.lang.Double(_)).to[immutable.Set], FilterApi.doubleColumn)
-}
-
-private trait FilterValueSet[V <: Comparable[V], C <: Column[V]] {
-
-  def value: Set[V]
-
-  def columnFactory: String => C
-}
-
-private class FilterValueSetImpl[V <: Comparable[V], C <: Column[V]](override val value: Set[V],
-                                                                     override val columnFactory: String => C
-                                                                    ) extends FilterValueSet[V, C]

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/FilterSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/FilterSpec.scala
@@ -40,6 +40,11 @@ class FilterSpec extends FlatSpec with Matchers {
     predicate.toString  should be("lteq(i, 1)")
   }
 
+  it should "build in predicate" in {
+    val predicate = (Col("i") in Seq(1, 2, 3)).toPredicate(valueCodecConfiguration)
+    predicate.toString should be("userdefinedbyinstance(i, in(1, 2, 3))")
+  }
+
   it should "build not predicate" in {
     val predicate = (!(Col("i") === 1)).toPredicate(valueCodecConfiguration)
     predicate.toString  should be("not(eq(i, 1))")

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/FilterSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/FilterSpec.scala
@@ -40,7 +40,12 @@ class FilterSpec extends FlatSpec with Matchers {
     predicate.toString  should be("lteq(i, 1)")
   }
 
-  it should "build in predicate" in {
+  it should "build in predicate with varargs" in {
+    val predicate = (Col("i") in(1, 2, 3)).toPredicate(valueCodecConfiguration)
+    predicate.toString should be("userdefinedbyinstance(i, in(1, 2, 3))")
+  }
+
+  it should "build in predicate with collection" in {
     val predicate = (Col("i") in Seq(1, 2, 3)).toPredicate(valueCodecConfiguration)
     predicate.toString should be("userdefinedbyinstance(i, in(1, 2, 3))")
   }


### PR DESCRIPTION
As discussed in #111, this adds an SQL-style `in` operator for before-read filtering.

It supports most the same data types that are supported by the `===` operator, but I decided to leave `Boolean` out, on the grounds that filtering on a set of more than one `Boolean` is pointless. 

It performs block-level filtering by doing a linear scan to look for at least one value that falls within the block's minimum and maximum range. That should be reasonably efficient as long as the list of items to match on doesn't get too big, and the data is roughly sorted by the field being filtered on. I'm guessing that that's a reasonable trade-off as long as this operator is typically being used for either a synthetic key lookup or a small set of target values.