### PR TITLE
Add terrible hacky code to access schema from reader

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ lazy val publishSettings = {
     ),
     Test / publishArtifact := false,
     IntegrationTest / publishArtifact := false
-  ) ++ Signing.signingSettings
+  ) ++ (if (sys.env contains "SONATYPE_USER_NAME") Signing.signingSettings else Seq.empty)
 }
 
 lazy val itSettings = Defaults.itSettings ++

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReadSupport.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReadSupport.scala
@@ -13,6 +13,9 @@ import scala.collection.JavaConverters._
 
 private[parquet4s] class ParquetReadSupport extends ReadSupport[RowParquetRecord] {
 
+  private var types: List[Type] = null;
+  def schema = types
+
   override def prepareForRead(
                                configuration: Configuration,
                                keyValueMetaData: util.Map[String, String],
@@ -21,7 +24,10 @@ private[parquet4s] class ParquetReadSupport extends ReadSupport[RowParquetRecord
                              ): RecordMaterializer[RowParquetRecord] =
     new ParquetRecordMaterializer(fileSchema)
 
-  override def init(context: InitContext): ReadSupport.ReadContext = new ReadSupport.ReadContext(context.getFileSchema)
+  override def init(context: InitContext): ReadSupport.ReadContext = {
+    types = context.getFileSchema.getFields.asScala.toList
+    new ReadSupport.ReadContext(context.getFileSchema)
+  }
 
 }
 

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable.ArrayBuffer
   * Special type of [[Value]] that represents a record in Parquet file.
   * A record is a complex type of data that contains series of other value entries inside.
   */
-sealed trait ParquetRecord extends Value {
+sealed trait ParquetRecord extends Value  {
 
   type Self
 
@@ -48,7 +48,7 @@ object RowParquetRecord {
   * a non-empty list of fields with other values associated with each of them.
   * Cannot be empty while being saved.
   */
-class RowParquetRecord private extends ParquetRecord {
+class RowParquetRecord private extends ParquetRecord with Iterable[(String, Value)] {
 
   override type Self = this.type
 
@@ -59,6 +59,8 @@ class RowParquetRecord private extends ParquetRecord {
     values.append((name, value))
     this
   }
+
+  override def iterator: Iterator[(String, Value)] = values.iterator
 
   /**
     * @return fields held in record
@@ -146,6 +148,7 @@ class ListParquetRecord private extends ParquetRecord {
     values.append(value)
     this
   }
+
 
   /**
     * @return collection of elements held in record

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetSchemaResolver.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetSchemaResolver.scala
@@ -51,7 +51,7 @@ object ParquetSchemaResolver
 
 object Message {
 
-  val name = "parquet4s-schema"
+  val name = "Parquet4sSchema"
 
   def apply(fields: Type*): MessageType = Types.buildMessage().addFields(fields:_*).named(name)
 

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetIterableSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetIterableSpec.scala
@@ -31,6 +31,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
   "iterator" should "build instance of iterator over row class containing record reader" in {
     newParquetIterable[TestRow](
       mockTestBuilder(mock[HadoopParquetReader[RowParquetRecord]]),
+      new ParquetReadSupport,
       options
     ).iterator should be(an[Iterator[_]])
   }
@@ -38,9 +39,9 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
   it should "build a new iterator with new reader every time called" in {
     val builder = mockTestBuilder(mock[HadoopParquetReader[RowParquetRecord]])
 
-    newParquetIterable[TestRow](builder, options).iterator should be(an[Iterator[_]])
-    newParquetIterable[TestRow](builder, options).iterator should be(an[Iterator[_]])
-    newParquetIterable[TestRow](builder, options).iterator should be(an[Iterator[_]])
+    newParquetIterable[TestRow](builder, new ParquetReadSupport, options).iterator should be(an[Iterator[_]])
+    newParquetIterable[TestRow](builder, new ParquetReadSupport, options).iterator should be(an[Iterator[_]])
+    newParquetIterable[TestRow](builder, new ParquetReadSupport, options).iterator should be(an[Iterator[_]])
 
     builder.withConf(*) wasCalled 3.times
     builder.withFilter(*) wasCalled 3.times
@@ -51,7 +52,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns null
 
-    newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator.hasNext should be(false)
+    newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator.hasNext should be(false)
 
     reader.read() was called
   }
@@ -60,7 +61,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns testRecord(1)
 
-    newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator.hasNext should be(true)
+    newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator.hasNext should be(true)
 
     reader.read() was called
   }
@@ -70,7 +71,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns null
 
-    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator
+    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator
     iterator.hasNext should be(false)
     iterator.hasNext should be(false)
     iterator.hasNext should be(false)
@@ -82,7 +83,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns testRecord(1)
 
-    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator
+    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator
     iterator.hasNext should be(true)
     iterator.hasNext should be(true)
     iterator.hasNext should be(true)
@@ -94,21 +95,21 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns testRecord(1)
 
-    newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator.next should be(TestRow(1))
+    newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator.next should be(TestRow(1))
   }
 
   it should "throw NoSuchElementException for empty resource" in {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns null
 
-    a[NoSuchElementException] should be thrownBy newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator.next
+    a[NoSuchElementException] should be thrownBy newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator.next
   }
 
   it should "try to read record only once in case of sequential calls for missing record" in {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns null
 
-    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator
+    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator
     a[NoSuchElementException] should be thrownBy iterator.next
     a[NoSuchElementException] should be thrownBy iterator.next
     a[NoSuchElementException] should be thrownBy iterator.next
@@ -120,7 +121,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns testRecord(1) andThen testRecord(2) andThen testRecord(3) andThen null
 
-    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator
+    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator
     iterator.next should be(TestRow(1))
     iterator.next should be(TestRow(2))
     iterator.next should be(TestRow(3))
@@ -131,7 +132,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns null
 
-    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator
+    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator
     iterator.hasNext should be(false)
     a[NoSuchElementException] should be thrownBy iterator.next
 
@@ -142,7 +143,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns testRecord(1)
 
-    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator
+    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator
     iterator.hasNext should be(true)
     iterator.next should be(TestRow(1))
 
@@ -153,7 +154,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns testRecord(1) andThen null
 
-    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator
+    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator
     iterator.hasNext should be(true)
     iterator.next should be(TestRow(1))
     iterator.hasNext should be(false)
@@ -166,7 +167,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
     reader.read() returns testRecord(1) andThen testRecord(2) andThen null
 
-    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), options).iterator
+    val iterator = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options).iterator
     iterator.hasNext should be(true)
     iterator.next should be(TestRow(1))
     iterator.hasNext should be(true)
@@ -180,7 +181,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
   "close" should "close reader created by iterator" in {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
 
-    val iterable = newParquetIterable[TestRow](mockTestBuilder(reader), options)
+    val iterable = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options)
     iterable.iterator
     iterable.close()
 
@@ -189,7 +190,7 @@ class ParquetIterableSpec extends FlatSpec with Matchers with IdiomaticMockito {
 
   it should "close all readers created by multiple iterators" in {
     val reader = mock[HadoopParquetReader[RowParquetRecord]]
-    val iterable = newParquetIterable[TestRow](mockTestBuilder(reader), options)
+    val iterable = newParquetIterable[TestRow](mockTestBuilder(reader), new ParquetReadSupport, options)
 
     iterable.iterator
     iterable.iterator


### PR DESCRIPTION
This, as far as I can tell, is probably the minimal change to your library that will meet my requirements, but the code is terrible.  I would love your advice about how to do it more cleanly.


I'm writing code that does configuration-driven ETL on existing parquet files to produce new, transformed parquet files, but my code does not know before reading the input file what the schema is.


For concreteness, you could imagine that my code needs to take and input path (to a parquet file with unknown schema) and a list of column names, and then yield a new parquet file containing the same contents as the old, except with the given columns encrypted on a per-value basis.


The user code that I am writing based on this terrible ugly patch looks like this:
```
object cp {

  private implicit object decoder extends ParquetRecordDecoder[RowParquetRecord] {
    override def decode(record: RowParquetRecord, configuration: ValueCodecConfiguration): RowParquetRecord = record
  }

  private implicit object encoder extends ParquetRecordEncoder[RowParquetRecord] {
    override def encode(entity: RowParquetRecord, configuration: ValueCodecConfiguration): RowParquetRecord = entity
  }

  def apply(src: String, srcOpts: ParquetReader.Options,  dst: String, dstOpts: ParquetWriter.Options) = {
    val in = ParquetReader.read[RowParquetRecord](src)
    if (in.iterator.hasNext) {
      implicit object schema_resolver extends ParquetSchemaResolver[RowParquetRecord] {
        override def resolveSchema: List[Type] = in.schema
      }
      println("Schema:  " + in.schema)
      val out = ParquetWriter.writer[RowParquetRecord](dst, dstOpts)
      out.write(in)
      out.close()
    }
  }
}
```