### PR TITLE
Mutable records

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,15 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-deps-
       # compile all sources
-      - run: cat /dev/null | sbt test:compile it:compile
+      - run: cat /dev/null | sbt +test:compile +it:compile
       # cache dependencies
       - save_cache:
           paths:
           - ~/.ivy2
           - ~/.sbt
           key: v1-deps--{{ checksum "build.sbt" }}
-      # run tests!
-      - run: cat /dev/null | sbt test it:test
+      # run tests! in every supported Scala version
+      - run: cat /dev/null | sbt +test +it:test
 
   release:
     docker:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ ParquetStreams.fromParquet[Stats](
 
 > **TAKE NOTE!**
 >
-> Take note that due to an issue with implicit resolution in **Scala 2.11** you may need to define all parameters of `ParquetStreams.fromParquet` even if some have default values. It specifically refers to a case when you would like to omit `options` but define `filter`. Such situation doesn't appear in Scala 2.12 and 2.13.
+> Take note that due to an issue with implicit resolution in **Scala 2.11** you may need to define all parameters of `ParquetStreams.fromParquet` even if some have default values. Parameters must be specified in default order even when you use named arguments. It specifically refers to a case when you would like to omit `options` but define `filter`. Such a situation doesn't appear in Scala 2.12 and 2.13.
 
 You can construct filter predicates using `===`, `!==`, `>`, `>=`, `<`, `<=`, and `in` operators on columns containing primitive values. You can combine and modify predicates using `&&`, `||` and `!` operators. `in` looks for values in a list of keys, similar to SQL's `in` operator. Mind that operations on `java.sql.Timestamp` and `java.time.LocalDateTime` are not supported as Parquet still not allows filtering by `Int96` out of the box.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 import bloop.integrations.sbt.BloopDefaults
 
 
-lazy val supportedScalaVersions = Seq("2.11.12", "2.12.10", "2.13.1")
+lazy val supportedScalaVersions = Seq("2.11.12", "2.12.11", "2.13.2")
 
 ThisBuild / organization := "com.github.mjakubowski84"
 ThisBuild / version := "1.1.0-SNAPSHOT"
 ThisBuild / isSnapshot := true
-ThisBuild / scalaVersion := "2.13.1"
+ThisBuild / scalaVersion := "2.13.2"
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-target:jvm-1.8")
 ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-unchecked", "-deprecation", "-feature")
 ThisBuild / resolvers := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ lazy val publishSettings = {
     ),
     Test / publishArtifact := false,
     IntegrationTest / publishArtifact := false
-  ) ++ Signing.signingSettings
+  ) ++ (if (sys.env contains "SONATYPE_USER_NAME") Signing.signingSettings else Seq.empty)
 }
 
 lazy val itSettings = Defaults.itSettings ++

--- a/core/src/main/scala-2.11/com/github/mjakubowski84/parquet4s/ShrinkableCompat.scala
+++ b/core/src/main/scala-2.11/com/github/mjakubowski84/parquet4s/ShrinkableCompat.scala
@@ -1,0 +1,27 @@
+package com.github.mjakubowski84.parquet4s
+
+trait ShrinkableCompat {
+
+  this: MapParquetRecord =>
+
+  /** Removes a single entry from this map.
+   *
+   *  @param key  the key of the entry to remove.
+   *  @return the MapParquetRecord itself
+   */
+  override def -=(key: Value): This = {
+    entries -= key
+    this
+  }
+
+  /** ${Add}s a single element to this map.
+   *
+   *  @param elem  the element to $add.
+   *  @return the MapParquetRecord itself
+   */
+  override def +=(elem: (Value, Value)): This = {
+    entries += elem
+    this
+  }
+
+}

--- a/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ShrinkableCompat.scala
+++ b/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ShrinkableCompat.scala
@@ -1,0 +1,27 @@
+package com.github.mjakubowski84.parquet4s
+
+trait ShrinkableCompat {
+
+  this: MapParquetRecord =>
+
+  /** Removes a single entry from this map.
+   *
+   *  @param key  the key of the entry to remove.
+   *  @return the MapParquetRecord itself
+   */
+  override def -=(key: Value): This = {
+    entries -= key
+    this
+  }
+
+  /** ${Add}s a single element to this map.
+   *
+   *  @param elem  the element to $add.
+   *  @return the MapParquetRecord itself
+   */
+  override def +=(elem: (Value, Value)): This = {
+    entries += elem
+    this
+  }
+
+}

--- a/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ShrinkableCompat.scala
+++ b/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ShrinkableCompat.scala
@@ -1,0 +1,27 @@
+package com.github.mjakubowski84.parquet4s
+
+trait ShrinkableCompat {
+
+  this: MapParquetRecord =>
+
+  /** Removes a single entry from this map.
+   *
+   *  @param key  the key of the entry to remove.
+   *  @return the MapParquetRecord itself
+   */
+  override def subtractOne(key: Value): This = {
+    entries -= key
+    this
+  }
+
+  /** ${Add}s a single element to this map.
+   *
+   *  @param elem  the element to $add.
+   *  @return the MapParquetRecord itself
+   */
+  override def addOne(elem: (Value, Value)): This = {
+    entries += elem
+    this
+  }
+
+}

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReadSupport.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReadSupport.scala
@@ -35,10 +35,10 @@ private class ParquetRecordMaterializer(schema: MessageType) extends RecordMater
 
 }
 
-private abstract class ParquetRecordConverter[R <: ParquetRecord](
+private abstract class ParquetRecordConverter[R <: ParquetRecord[_]](
                                                            schema: GroupType,
                                                            name: Option[String],
-                                                           parent: Option[ParquetRecordConverter[_ <: ParquetRecord]]
+                                                           parent: Option[ParquetRecordConverter[_ <: ParquetRecord[_]]]
                                                          ) extends GroupConverter {
 
   protected var record: R = _
@@ -138,7 +138,7 @@ private abstract class ParquetRecordConverter[R <: ParquetRecord](
 
 }
 
-private class RowParquetRecordConverter(schema: GroupType, name: Option[String], parent: Option[ParquetRecordConverter[_ <: ParquetRecord]])
+private class RowParquetRecordConverter(schema: GroupType, name: Option[String], parent: Option[ParquetRecordConverter[_ <: ParquetRecord[_]]])
   extends ParquetRecordConverter[RowParquetRecord](schema, name, parent) {
 
   def this(schema: GroupType) {
@@ -151,7 +151,7 @@ private class RowParquetRecordConverter(schema: GroupType, name: Option[String],
   
 }
 
-private class ListParquetRecordConverter(schema: GroupType, name: String, parent: ParquetRecordConverter[_ <: ParquetRecord])
+private class ListParquetRecordConverter(schema: GroupType, name: String, parent: ParquetRecordConverter[_ <: ParquetRecord[_]])
   extends ParquetRecordConverter[ListParquetRecord](schema, Option(name), Option(parent)){
 
   override def start(): Unit = {
@@ -160,7 +160,7 @@ private class ListParquetRecordConverter(schema: GroupType, name: String, parent
 
 }
 
-private class MapParquetRecordConverter(schema: GroupType, name: String, parent: ParquetRecordConverter[_ <: ParquetRecord])
+private class MapParquetRecordConverter(schema: GroupType, name: String, parent: ParquetRecordConverter[_ <: ParquetRecord[_]])
   extends ParquetRecordConverter[MapParquetRecord](schema, Option(name), Option(parent)) {
 
   override def start(): Unit = {

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
@@ -3,13 +3,14 @@ package com.github.mjakubowski84.parquet4s
 import org.apache.parquet.io.api.RecordConsumer
 import org.apache.parquet.schema.Type
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 /**
   * Special type of [[Value]] that represents a record in Parquet file.
   * A record is a complex type of data that contains series of other value entries inside.
   */
-sealed trait ParquetRecord extends Value {
+sealed trait ParquetRecord[A] extends Value with Iterable[A] {
 
   type Self
 
@@ -48,7 +49,7 @@ object RowParquetRecord {
   * a non-empty list of fields with other values associated with each of them.
   * Cannot be empty while being saved.
   */
-class RowParquetRecord private extends ParquetRecord {
+class RowParquetRecord private extends ParquetRecord[(String, Value)] with mutable.Seq[(String, Value)]{
 
   override type Self = this.type
 
@@ -64,6 +65,40 @@ class RowParquetRecord private extends ParquetRecord {
     * @return fields held in record
     */
   def fields: Map[String, Value] = values.toMap
+
+
+  override def iterator: Iterator[(String, Value)] = values.iterator
+
+  /** Get the field name and value at the specified index.
+    *
+    * @param idx The index
+    * @return The field name and value
+    *  @throws   IndexOutOfBoundsException if the index is not valid.
+    */
+  override def apply(idx: Int) = values(idx)
+
+
+  /** Replaces field name and value at given index with a new field name and value.
+    *
+    *  @param idx      the index of the element to replace.
+    *  @param newEntry     the new field name and value.
+    *  @throws   IndexOutOfBoundsException if the index is not valid.
+    */
+  override def update(idx: Int, newEntry: (String, Value)): Unit = values(idx) = newEntry
+
+  /** Replaces value at given index with a new value.
+    *
+    *  @param idx      the index of the value to replace.
+    *  @param newVal     the new value.
+    *  @throws   IndexOutOfBoundsException if the index is not valid.
+    */
+  def update(idx: Int, newVal: Value) = values(idx) = values(idx).copy(_2 = newVal)
+
+  /**
+    *
+    * @return The number of columns in this record
+    */
+  def length = values.length
 
   override def toString: String =
     values
@@ -91,7 +126,7 @@ class RowParquetRecord private extends ParquetRecord {
   }
 
 
-  def canEqual(other: Any): Boolean = other.isInstanceOf[RowParquetRecord]
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[RowParquetRecord]
 
   override def equals(other: Any): Boolean = other match {
     case that: RowParquetRecord =>
@@ -130,7 +165,7 @@ object ListParquetRecord {
   * A type of [[ParquetRecord]] that represents a record holding a repeated amount of entries
   * of the same type. Can be empty.
   */
-class ListParquetRecord private extends ParquetRecord {
+class ListParquetRecord private extends ParquetRecord[Value] with mutable.Seq[Value]{
   import ListParquetRecord._
 
   override type Self = this.type
@@ -151,6 +186,26 @@ class ListParquetRecord private extends ParquetRecord {
     * @return collection of elements held in record
     */
   def elements: List[Value] = values.toList // TODO let's use vector, check if ArrayBuffer is a good choice
+
+  /** Get the value at the specified index.
+    *
+    * @param idx The index
+    * @return The value
+    *  @throws   IndexOutOfBoundsException if the index is not valid.
+    */
+  def apply(idx: Int) = values(idx)
+
+  /** Replaces value at given index with a new value.
+    *
+    *  @param idx      the index of the element to replace.
+    *  @param newVal     the new value.
+    *  @throws   IndexOutOfBoundsException if the index is not valid.
+    */
+  def update(idx: Int, newVal: Value) = values(idx) = newVal
+  def length = values.length
+
+
+  override def iterator: Iterator[Value] = values.iterator
 
   override def toString: String = values.mkString(getClass.getSimpleName + " (", ",", ")")
 
@@ -174,7 +229,7 @@ class ListParquetRecord private extends ParquetRecord {
     recordConsumer.endGroup()
   }
 
-  def canEqual(other: Any): Boolean = other.isInstanceOf[ListParquetRecord]
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[ListParquetRecord]
 
   override def equals(other: Any): Boolean = other match {
     case that: ListParquetRecord =>
@@ -209,12 +264,12 @@ object MapParquetRecord {
   * A type of [[ParquetRecord]] that represents a map from one entry type to another. Can be empty.
   * A key entry cannot be null, a value entry can.
   */
-class MapParquetRecord private extends ParquetRecord {
+class MapParquetRecord private extends ParquetRecord[(Value, Value)] with mutable.Map[Value, Value] {
   import MapParquetRecord._
 
   override type Self = this.type
 
-  private val values = scala.collection.mutable.Map.empty[Value, Value]
+  private val entries = scala.collection.mutable.Map.empty[Value, Value]
 
   override def add(name: String, value: Value): Self = {
     val keyValueRecord = value.asInstanceOf[RowParquetRecord]
@@ -224,31 +279,84 @@ class MapParquetRecord private extends ParquetRecord {
   }
 
   def add(key: Value, value: Value): Self = {
-    values.put(key, value)
+    entries.put(key, value)
     this
   }
 
   /**
     * @return map of values held by record
     */
-  def getMap: Map[Value, Value] = values.toMap
+  def getMap: Map[Value, Value] = entries.toMap
+
+  /** Retrieves the value which is associated with the given key.
+    * If there is no entry for the given key,throws a
+    *  `NoSuchElementException`.
+    *
+    *  @param  key the key
+    *  @return     the value associated with the given key, or the result of the
+    *              map's `default` method, if none exists.
+    */
+  override def apply(key: Value): Value = entries(key)
+
+
+  /** Optionally returns the value associated with a key.
+    *
+    *  @param  key    the key value
+    *  @return an option value containing the value associated with `key` in this map,
+    *          or `None` if none exists.
+    */
+  override def get(key: Value): Option[Value] = entries.get(key)
+
+  /** Adds a new key/value pair to this map.
+    *  If the map already contains a
+    *  mapping for the key, it will be overridden by the new value.
+    *
+    *  @param key    The key to update
+    *  @param newVal  The new value
+    */
+  override def update(key: Value, newVal: Value) = entries(key) = newVal
+
+  override def keys = entries.keys
+
+  /** Removes a single entry from this map.
+    *
+    *  @param key  the key of the entry to remove.
+    *  @return the MapParquetRecord itself
+    */
+  override def subtractOne(key: Value) = {
+    entries.subtractOne(key)
+    this
+  }
+
+
+  /** ${Add}s a single element to this map.
+    *
+    *  @param elem  the element to $add.
+    *  @return the MapParquetRecord itself
+    */
+  override def addOne(elem: (Value, Value)) = {
+    entries.addOne(elem)
+    this
+  }
+
+  override def iterator: Iterator[(Value, Value)] = entries.iterator
 
   override def toString: String =
-    values
+    entries
       .map { case (key, value) => s"$key=$value"}
       .mkString(getClass.getSimpleName + " (", ",", ")")
 
   override def write(schema: Type, recordConsumer: RecordConsumer): Unit = {
     recordConsumer.startGroup()
 
-    if (values.nonEmpty) {
+    if (entries.nonEmpty) {
       val groupSchema = schema.asGroupType()
       val mapKeyValueSchema = groupSchema.getType(MapKeyValueFieldName).asGroupType()
       val mapKeyValueIndex = groupSchema.getFieldIndex(MapKeyValueFieldName)
 
       recordConsumer.startField(MapKeyValueFieldName, mapKeyValueIndex)
 
-      values.foreach { case (key, value) =>
+      entries.foreach { case (key, value) =>
         RowParquetRecord(KeyFieldName -> key, ValueFieldName -> value).write(mapKeyValueSchema, recordConsumer)
       }
 
@@ -258,16 +366,16 @@ class MapParquetRecord private extends ParquetRecord {
     recordConsumer.endGroup()
   }
 
-  def canEqual(other: Any): Boolean = other.isInstanceOf[MapParquetRecord]
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[MapParquetRecord]
 
   override def equals(other: Any): Boolean = other match {
     case that: MapParquetRecord =>
-      (that canEqual this) && values == that.values
+      (that canEqual this) && entries == that.entries
     case _ => false
   }
 
   override def hashCode(): Int = {
-    val state = Seq(values)
+    val state = Seq(entries)
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
 

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
@@ -50,7 +50,7 @@ object ParquetRecordDecoder {
     new ParquetRecordDecoder[FieldType[FieldName, Head] :: Tail] {
       override def decode(record: RowParquetRecord, configuration: ValueCodecConfiguration): FieldType[FieldName, Head] :: Tail = {
         val fieldName = witness.value.name
-        val fieldValue = record.fields.getOrElse(fieldName, NullValue)
+        val fieldValue = record.get(fieldName)
         val decodedFieldValue = try {
           headDecoder.decode(fieldValue, configuration)
         } catch {

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
@@ -166,7 +166,7 @@ private class ParquetWriteSupport(schema: MessageType, metadata: Map[String, Str
 
   override def write(record: RowParquetRecord): Unit = {
     consumer.startMessage()
-    record.fields.foreach {
+    record.iterator.foreach {
       case (_, NullValue) =>
         // ignoring nulls
       case (name, value) =>

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ValueCodec.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ValueCodec.scala
@@ -318,7 +318,7 @@ trait ComplexValueCodecs {
     override def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): Col[T] =
       value match {
         case listRecord: ListParquetRecord =>
-          collectionTransformer.to(listRecord.elements.map((elementCodec.decode _).curried(_)(configuration)))
+          collectionTransformer.to(listRecord.toList.map((elementCodec.decode _).curried(_)(configuration)))
       }
 
     override def encodeNonNull(data: Col[T], configuration: ValueCodecConfiguration): Value =
@@ -352,7 +352,7 @@ trait ComplexValueCodecs {
     override def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): Map[K, V] =
       value match {
         case mapParquetRecord: MapParquetRecord =>
-          mapParquetRecord.getMap.map { case (mapKey, mapValue) =>
+          mapParquetRecord.toMap.map { case (mapKey, mapValue) =>
             require(mapKey != NullValue, "Map cannot have null keys")
             kCodec.decode(mapKey, configuration) -> vCodec.decode(mapValue, configuration)
           }

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetRecordDecoderSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetRecordDecoderSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ParquetRecordDecoderSpec extends FlatSpec with Matchers {
 
-  def dateTimeAsBinary(epochDays: Int, timeInNanos: Long, timeZone: TimeZone) =
+  def dateTimeAsBinary(epochDays: Int, timeInNanos: Long, timeZone: TimeZone): BinaryValue =
     BinaryValue {
       val buf = ByteBuffer.allocate(12).order(ByteOrder.LITTLE_ENDIAN)
       // tz offset is expressed in millis while time in Parquet is expressed in nanos

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/akka/WriteAndReadFilteredAkkaApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/akka/WriteAndReadFilteredAkkaApp.scala
@@ -3,7 +3,7 @@ package com.github.mjakubowski84.parquet4s.akka
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.{ActorMaterializer, Materializer}
-import com.github.mjakubowski84.parquet4s.{Col, ParquetStreams}
+import com.github.mjakubowski84.parquet4s.{Col, ParquetReader, ParquetStreams}
 import com.google.common.io.Files
 
 import scala.concurrent.Future
@@ -31,6 +31,7 @@ object WriteAndReadFilteredAkkaApp extends App {
   implicit val materializer: Materializer = ActorMaterializer()
   import system.dispatcher
 
+  val options = ParquetReader.Options()
   val printingSink = Sink.foreach(println)
 
   for {
@@ -38,9 +39,9 @@ object WriteAndReadFilteredAkkaApp extends App {
     _ <- Source(data).runWith(ParquetStreams.toParquetSingleFile(s"$path/data.parquet"))
     // read filtered
     _ <- Future(println("""dict == "A""""))
-    _ <- ParquetStreams.fromParquet[Data](path, filter = Col("dict") === Dict.A).runWith(printingSink)
+    _ <- ParquetStreams.fromParquet[Data](path, options = options, filter = Col("dict") === Dict.A).runWith(printingSink)
     _ <- Future(println("""id >= 20 && id < 40"""))
-    _ <- ParquetStreams.fromParquet[Data](path, filter = Col("id") >= 20 && Col("id") < 40).runWith(printingSink)
+    _ <- ParquetStreams.fromParquet[Data](path, options = options, filter = Col("id") >= 20 && Col("id") < 40).runWith(printingSink)
     // finish
     _ <- system.terminate()
   } yield ()

--- a/project/DependecyVersions.scala
+++ b/project/DependecyVersions.scala
@@ -1,6 +1,6 @@
 object DependecyVersions {
   val parquetVersion = "1.10.1"
-  val sparkVersion = "2.4.4"
+  val sparkVersion = "2.4.5"
   val hadoopVersion = "2.9.2"
   val slf4jVersion = "1.7.25"
   val akkaVersion = "2.5.27"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.10


### PR DESCRIPTION
@mac01021 Here I modified your PR so that it works with all Scala versions. It is based on your first PR with extension of Iterable. I added also a simple solution for fast lookup in RowParquetRecord. It is not-so-nice implementation but I find it good enough as the whole implementation is mutable and not thread-safe.
I already used those improvements in all conversions. We should achieve some performance boost for whole library (I need to add some benchmarks...)
I added also some cross-build fixes in examples that I still didn't fix in master (only in 1.1 WIP). I also updated Scala minor versions.
