### PR TITLE
Add read support for nonstandard list encodings

### DIFF
--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
@@ -225,8 +225,10 @@ class ListParquetRecord private extends ParquetRecord[Value] with mutable.Seq[Va
 
   override def add(name: String, value: Value): This =
     value match {
-      case repeated: RowParquetRecord if repeated.headOption.map(_._1).contains(ElementFieldName) =>
+      case repeated: RowParquetRecord if repeated.length==1 && repeated.head._1 == ElementFieldName =>
         add(repeated.head._2)
+      case repeated: RowParquetRecord if repeated.isEmpty =>
+        add(NullValue)
       case _ =>
         add(value)
     }

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
@@ -225,7 +225,13 @@ class ListParquetRecord private extends ParquetRecord[Value] with mutable.Seq[Va
 
   override def add(name: String, value: Value): This = {
     // name should always be equal to ListFieldName
-    add(value.asInstanceOf[RowParquetRecord].get(ElementFieldName))
+    if (value.isInstanceOf[RowParquetRecord]) {
+      val repeated = value.asInstanceOf[RowParquetRecord]
+      if (repeated.length > 1 || repeated.head._1 != ElementFieldName) add(value)
+      else add(value.asInstanceOf[RowParquetRecord].get(ElementFieldName))
+    } else {
+      add(value)
+    }
   }
 
   /**

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
@@ -223,16 +223,13 @@ class ListParquetRecord private extends ParquetRecord[Value] with mutable.Seq[Va
 
   private val values = mutable.ArrayBuffer.empty[Value]
 
-  override def add(name: String, value: Value): This = {
-    // name should always be equal to ListFieldName
-    if (value.isInstanceOf[RowParquetRecord]) {
-      val repeated = value.asInstanceOf[RowParquetRecord]
-      if (repeated.length > 1 || repeated.head._1 != ElementFieldName) add(value)
-      else add(value.asInstanceOf[RowParquetRecord].get(ElementFieldName))
-    } else {
-      add(value)
+  override def add(name: String, value: Value): This =
+    value match {
+      case repeated: RowParquetRecord if repeated.headOption.map(_._1).contains(ElementFieldName) =>
+        add(repeated.head._2)
+      case _ =>
+        add(value)
     }
-  }
 
   /**
     * Appends value to the list.

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetRecordSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetRecordSpec.scala
@@ -93,6 +93,19 @@ class ParquetRecordSpec extends FlatSpec with Matchers {
     lst(1).asInstanceOf[RowParquetRecord].get("d") should be(IntValue(4))
   }
 
+  "ListParquetRecord" should "accumulate null values" in {
+    val lst = ListParquetRecord.empty
+    val nofields = RowParquetRecord()
+    lst.add("array", nofields)
+    lst.add("array", nofields)
+    lst.add("array", nofields)
+    lst should have size 3
+    for { elem <- lst } {
+      elem should be(NullValue)
+    }
+
+  }
+
 
   it should "fail to get field from invalid index" in {
     an[NoSuchElementException] should be thrownBy ListParquetRecord.empty.head

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetRecordSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetRecordSpec.scala
@@ -1,5 +1,6 @@
 package com.github.mjakubowski84.parquet4s
 
+import org.apache.parquet.io.api.Binary
 import org.scalatest.{FlatSpec, Matchers}
 
 class ParquetRecordSpec extends FlatSpec with Matchers {
@@ -43,6 +44,55 @@ class ParquetRecordSpec extends FlatSpec with Matchers {
     record should be(empty)
     record should have size 0
   }
+
+  "ListParquetRecord" should "accumulate normal primitive values" in {
+    val lst = ListParquetRecord.empty
+    val b1 = Binary.fromString("a string")
+    val b2 = Binary.fromString("another string")
+    lst.add("list", RowParquetRecord("element" -> BinaryValue(b1)))
+    lst.add("list", RowParquetRecord("element" -> BinaryValue(b2)))
+    lst should have size 2
+    lst(0).asInstanceOf[BinaryValue].value should be(b1)
+    lst(1).asInstanceOf[BinaryValue].value should be(b2)
+  }
+
+  "ListParquetRecord" should "accumulate normal compound values" in {
+    val lst = ListParquetRecord.empty
+    val r1 = RowParquetRecord("a"-> IntValue(1), "b"-> IntValue(2))
+    val r2 = RowParquetRecord("c"-> IntValue(3), "d"-> IntValue(4))
+    lst.add("list", RowParquetRecord("element" -> r1))
+    lst.add("list", RowParquetRecord("element" -> r2))
+    lst should have size 2
+    lst(0).asInstanceOf[RowParquetRecord].get("a") should be(IntValue(1))
+    lst(0).asInstanceOf[RowParquetRecord].get("b") should be(IntValue(2))
+    lst(1).asInstanceOf[RowParquetRecord].get("c") should be(IntValue(3))
+    lst(1).asInstanceOf[RowParquetRecord].get("d") should be(IntValue(4))
+  }
+
+  "ListParquetRecord" should "accumulate legacy primitive values" in {
+    val lst = ListParquetRecord.empty
+    val b1 = Binary.fromString("a string")
+    val b2 = Binary.fromString("another string")
+    lst.add("array",  BinaryValue(b1))
+    lst.add("array",  BinaryValue(b2))
+    lst should have size 2
+    lst(0).asInstanceOf[BinaryValue].value should be(b1)
+    lst(1).asInstanceOf[BinaryValue].value should be(b2)
+  }
+
+  "ListParquetRecord" should "accumulate legacy compound values" in {
+    val lst = ListParquetRecord.empty
+    val r1 = RowParquetRecord("a"-> IntValue(1), "b"-> IntValue(2))
+    val r2 = RowParquetRecord("c"-> IntValue(3), "d"-> IntValue(4))
+    lst.add("array", r1)
+    lst.add("array", r2)
+    lst should have size 2
+    lst(0).asInstanceOf[RowParquetRecord].get("a") should be(IntValue(1))
+    lst(0).asInstanceOf[RowParquetRecord].get("b") should be(IntValue(2))
+    lst(1).asInstanceOf[RowParquetRecord].get("c") should be(IntValue(3))
+    lst(1).asInstanceOf[RowParquetRecord].get("d") should be(IntValue(4))
+  }
+
 
   it should "fail to get field from invalid index" in {
     an[NoSuchElementException] should be thrownBy ListParquetRecord.empty.head


### PR DESCRIPTION
This doesn't have unit new unit tests yet.  

But it handles both regular files and my legacy file with no problems, as far as I can tell.

I am trying to figure out how to add some cases in `ParquetRecordDecoderSpec` (if that is even possible) that would correspond to the nonstandard encoding, but I may not have it figured out before you sleep tonight.