### PR TITLE
Determine schema name dynamically

### DIFF
--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
@@ -45,6 +45,7 @@ object RowParquetRecord {
 
   implicit def genericParquetSchemaResolver(implicit message: MessageType): ParquetSchemaResolver[RowParquetRecord] =
     new ParquetSchemaResolver[RowParquetRecord] {
+      override def name: String = message.getName
       override def resolveSchema: List[Type] = message.getFields.iterator().asScala.toList
     }
 

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetSchemaResolverSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetSchemaResolverSpec.scala
@@ -11,11 +11,11 @@ import org.scalatest.{FlatSpec, Matchers}
 class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
 
   "ParquetSchemaResolver" should "resolve schema for type with no fields" in {
-    resolveSchema[Empty] should be(Message())
+    resolveSchema[Empty] should be(Message(classOf[Empty].getCanonicalName))
   }
 
   it should "resolve schema for type with primitives" in {
-    resolveSchema[Primitives] should be(Message(
+    resolveSchema[Primitives] should be(Message(classOf[Primitives].getCanonicalName,
       Types.primitive(BOOLEAN, REQUIRED).named("boolean"),
       Types.primitive(INT32, REQUIRED).as(OriginalType.INT_32).named("int"),
       Types.primitive(INT64, REQUIRED).as(OriginalType.INT_64).named("long"),
@@ -34,14 +34,14 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing optional types" in {
-    resolveSchema[ContainsOption] should be(Message(
+    resolveSchema[ContainsOption] should be(Message(classOf[ContainsOption].getCanonicalName,
       Types.optional(INT32).as(OriginalType.INT_32).named("optional")
     ))
   }
 
   it should "resolve schema for type containing collections of primitives" in {
     val elementType = Types.required(INT32).as(OriginalType.INT_32).named(ListSchemaDef.ElementName)
-    resolveSchema[Collections] should be(Message(
+    resolveSchema[Collections] should be(Message(classOf[Collections].getCanonicalName,
       Types.optionalList.element(elementType).named("list"),
       Types.optionalList.element(elementType).named("seq"),
       Types.optionalList.element(elementType).named("vector"),
@@ -51,7 +51,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing collection of optional primitives" in {
-    resolveSchema[ContainsCollectionOfOptionalPrimitives] should be(Message(
+    resolveSchema[ContainsCollectionOfOptionalPrimitives] should be(Message(classOf[ContainsCollectionOfOptionalPrimitives].getCanonicalName,
       Types.optionalList
         .element(Types.optional(INT32).as(OriginalType.INT_32).named(ListSchemaDef.ElementName))
         .named("list")
@@ -59,7 +59,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing collection of collections of primitives" in {
-    resolveSchema[ContainsCollectionOfCollections] should be(Message(
+    resolveSchema[ContainsCollectionOfCollections] should be(Message(classOf[ContainsCollectionOfCollections].getCanonicalName,
       Types.optionalList
         .element(
           Types.optionalList
@@ -71,7 +71,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing map of primitives" in {
-    resolveSchema[ContainsMapOfPrimitives] should be(Message(
+    resolveSchema[ContainsMapOfPrimitives] should be(Message(classOf[ContainsMapOfPrimitives].getCanonicalName,
       Types.optionalMap()
         .key(Types.required(BINARY).as(OriginalType.UTF8).named(MapSchemaDef.KeyName))
         .value(Types.required(INT32).as(OriginalType.INT_32).named(MapSchemaDef.ValueName))
@@ -80,7 +80,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing map of optional primitives" in {
-    resolveSchema[ContainsMapOfOptionalPrimitives] should be(Message(
+    resolveSchema[ContainsMapOfOptionalPrimitives] should be(Message(classOf[ContainsMapOfOptionalPrimitives].getCanonicalName,
       Types.optionalMap()
         .key(Types.required(BINARY).as(OriginalType.UTF8).named(MapSchemaDef.KeyName))
         .value(Types.optional(INT32).as(OriginalType.INT_32).named(MapSchemaDef.ValueName))
@@ -89,7 +89,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing map of collections of primitives" in {
-    resolveSchema[ContainsMapOfCollectionsOfPrimitives] should be(Message(
+    resolveSchema[ContainsMapOfCollectionsOfPrimitives] should be(Message(classOf[ContainsMapOfCollectionsOfPrimitives].getCanonicalName,
       Types.optionalMap()
         .key(Types.required(BINARY).as(OriginalType.UTF8).named(MapSchemaDef.KeyName))
         .value(
@@ -101,7 +101,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing nested class" in {
-    resolveSchema[ContainsNestedClass] should be(Message(
+    resolveSchema[ContainsNestedClass] should be(Message(classOf[ContainsNestedClass].getCanonicalName,
       Types.optionalGroup()
         .addField(Types.required(INT32).as(OriginalType.INT_32).named("int"))
         .named("nested")
@@ -109,7 +109,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
   
   it should "resolve schema for type containing optional nested class" in {
-    resolveSchema[ContainsOptionalNestedClass] should be(Message(
+    resolveSchema[ContainsOptionalNestedClass] should be(Message(classOf[ContainsOptionalNestedClass].getCanonicalName,
       Types.optionalGroup()
         .addField(Types.required(INT32).as(OriginalType.INT_32).named("int"))
         .named("nestedOptional")
@@ -120,7 +120,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
     val elementType = Types.optionalGroup()
       .addField(Types.required(INT32).as(OriginalType.INT_32).named("int"))
       .named(ListSchemaDef.ElementName)
-    resolveSchema[CollectionsOfNestedClass] should be(Message(
+    resolveSchema[CollectionsOfNestedClass] should be(Message(classOf[CollectionsOfNestedClass].getCanonicalName,
       Types.optionalList.element(elementType).named("list"),
       Types.optionalList.element(elementType).named("seq"),
       Types.optionalList.element(elementType).named("vector"),
@@ -130,7 +130,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing map with nested class as value" in {
-    resolveSchema[ContainsMapOfNestedClassAsValue] should be(Message(
+    resolveSchema[ContainsMapOfNestedClassAsValue] should be(Message(classOf[ContainsMapOfNestedClassAsValue].getCanonicalName,
       Types.optionalMap()
         .key(Types.required(BINARY).as(OriginalType.UTF8).named(MapSchemaDef.KeyName))
         .value(
@@ -142,7 +142,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing map with optional nested class as value" in {
-    resolveSchema[ContainsMapOfOptionalNestedClassAsValue] should be(Message(
+    resolveSchema[ContainsMapOfOptionalNestedClassAsValue] should be(Message(classOf[ContainsMapOfOptionalNestedClassAsValue].getCanonicalName,
       Types.optionalMap()
         .key(Types.required(BINARY).as(OriginalType.UTF8).named(MapSchemaDef.KeyName))
         .value(
@@ -154,7 +154,7 @@ class ParquetSchemaResolverSpec extends FlatSpec with Matchers {
   }
 
   it should "resolve schema for type containing map with collection of nested classes as value" in {
-    resolveSchema[ContainsMapOfCollectionsOfNestedClassAsValue] should be(Message(
+    resolveSchema[ContainsMapOfCollectionsOfNestedClassAsValue] should be(Message(classOf[ContainsMapOfCollectionsOfNestedClassAsValue].getCanonicalName,
       Types.optionalMap()
         .key(Types.required(BINARY).as(OriginalType.UTF8).named(MapSchemaDef.KeyName))
         .value(


### PR DESCRIPTION
Parquet schemas have names.  I'm not completely sure why - as with Avro schemas, I've never seen anyone do anything significant with the name of the record type.  

Still, in the application I am currently working on, I am transforming a lot of different parquet files and, except for the columns I manipulate, I am looking to preserve as much as possible about the incoming file.

To that end, this patch:
- Adds a `name` method to the `ParquetSchemaResolver` trait
- Uses that name as the name of the generated `MessageType`
- When we derive a `ParquetSchemaResolver` instance for a case class using Shapeless, whenever possible, use the fully qualified name of the case class as the schema name
- If the case class has no name, because it is an anonymous class, revert to `parque4s_schema`
- When we get a `ParquetSchemaResolver[RowParquetRecord]` based on an implicit `MessageType`, use the name of the given `MessageType`.


This does not seem to be critical, so if you're worried it might break something not covered by tests (or just overly complicate your library), I won't pressure you to merge it.