### PR TITLE
fixing scope of PartitionLens

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ File system configs for S3, GCS or Hadoop can also be set programmatically to th
 Add the library to your dependencies:
 
 ```scala
-"com.github.mjakubowski84" %% "parquet4s-core" % "1.3.0"
+"com.github.mjakubowski84" %% "parquet4s-core" % "1.3.1"
 ```
 **Note:** Since version `0.5.0` you need to define your own version of `hadoop-client`:
 ```scala
@@ -79,7 +79,7 @@ try {
 Parquet4S has an integration module that allows you to read and write Parquet files using Akka Streams! Just import it:
 
 ```scala
-"com.github.mjakubowski84" %% "parquet4s-akka" % "1.3.0"
+"com.github.mjakubowski84" %% "parquet4s-akka" % "1.3.1"
 ```
 **Note:** Since version `0.5.0` you need to define your own version of `hadoop-client`:
 ```scala

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import bloop.integrations.sbt.BloopDefaults
 lazy val supportedScalaVersions = Seq("2.11.12", "2.12.11", "2.13.3")
 
 ThisBuild / organization := "com.github.mjakubowski84"
-ThisBuild / version := "1.4.0-SNAPSHOT"
-ThisBuild / isSnapshot := true
+ThisBuild / version := "1.3.1"
+ThisBuild / isSnapshot := false
 ThisBuild / scalaVersion := "2.11.12"
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-target:jvm-1.8")
 ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-unchecked", "-deprecation", "-feature")

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/PartitionLens.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/PartitionLens.scala
@@ -7,13 +7,13 @@ import shapeless.{::, HList, HNil, LabelledGeneric, Lazy, Witness}
   * Extracts a value of String field from a tree of case classes.
   * @tparam T type of the root case class
   */
-private[parquet4s] trait PartitionLens[T] {
+trait PartitionLens[T] {
 
   def apply(cursor: Cursor, obj: T): Either[PartitionLens.LensError, String]
 
 }
 
-private[parquet4s] object PartitionLens {
+object PartitionLens {
 
   case class LensError(cursor: Cursor, message: String)
 


### PR DESCRIPTION
private scope disallows to use implicit type classes in external packages making the functionality useless