### PR TITLE
Extend akka/fs2 partition name regex to include more allowed chars

### DIFF
--- a/akka/src/it/scala/com/github/mjakubowski84/parquet4s/IOOpsSpec.scala
+++ b/akka/src/it/scala/com/github/mjakubowski84/parquet4s/IOOpsSpec.scala
@@ -13,6 +13,7 @@ class IOOpsSpec
     with Matchers
     with IOOps
     with TestUtils
+    with PartitionTestUtils
     with BeforeAndAfter
     with EitherValues {
 
@@ -124,4 +125,40 @@ class IOOpsSpec
     findPartitionedPaths(tempPath, configuration) should be a Symbol("Left")
   }
 
+  "PartitionRegexp" should "match valid partition names and values" in {
+    val validNames = generatePartitionStrings(prefix = "testValue", withChars = allowedPartitionNameChars)
+    val validValues = generatePartitionStrings(prefix = "testName", withChars = allowedPartitionValueChars)
+    val validPairs = validNames.flatMap(name => validValues.map(value => name -> value))
+
+    validPairs.foreach { case (name, value) =>
+      s"$name=$value" match {
+        case IOOps.PartitionRegexp(`name`, `value`) =>
+          succeed
+
+        case _ =>
+          fail(
+            s"Expected a valid match for name [$name] and value [$value] but none was found"
+          )
+      }
+    }
+  }
+
+  it should "not match invalid partition names and values" in {
+    val invalidNames = generatePartitionStrings(prefix = "testValue", withChars = disallowedPartitionNameChars)
+    val invalidValues = generatePartitionStrings(prefix = "testName", withChars = disallowedPartitionValueChars)
+    val invalidPairs = invalidNames.flatMap(name => invalidValues.map(value => name -> value))
+
+    invalidPairs.foreach { case (name, value) =>
+      s"$name=$value" match {
+        case IOOps.PartitionRegexp(capturedName, capturedValue) =>
+          fail(
+            s"Expected no match for name [$name] and value [$value] " +
+              s"but one was found: [$capturedName, $capturedValue]"
+          )
+
+        case _ =>
+          succeed
+      }
+    }
+  }
 }

--- a/akka/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
+++ b/akka/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
@@ -19,7 +19,7 @@ private[parquet4s] object IOOps {
 
   private type Partition = (String, String)
 
-  private val PartitionRegexp: Regex = """([a-zA-Z0-9\._]+)=([a-zA-Z0-9\._]+)""".r
+  private[parquet4s] val PartitionRegexp: Regex = """([a-zA-Z0-9._]+)=([a-zA-Z0-9!\-_.*'()]+)""".r
 
 }
 

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/PartitionTestUtils.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/PartitionTestUtils.scala
@@ -1,0 +1,15 @@
+package com.github.mjakubowski84.parquet4s
+
+trait PartitionTestUtils {
+  val allChars: Seq[Char] = (Byte.MinValue to Byte.MaxValue).map(_.toChar)
+  val alphaNumericChars: Seq[Char] = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
+
+  val allowedPartitionNameChars: Seq[Char] = alphaNumericChars ++ Seq('.', '_')
+  val allowedPartitionValueChars: Seq[Char] = alphaNumericChars ++ Seq('!', '-', '_', '.', '*', '\'', '(', ')')
+
+  val disallowedPartitionNameChars: Seq[Char] = allChars.filterNot(allowedPartitionNameChars.contains)
+  val disallowedPartitionValueChars: Seq[Char] = allChars.filterNot(allowedPartitionValueChars.contains)
+
+  def generatePartitionStrings(prefix: String, withChars: Seq[Char]): Seq[String] =
+    withChars.map(char => s"$prefix$char")
+}

--- a/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/io.scala
+++ b/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/io.scala
@@ -25,7 +25,7 @@ private[parquet] object io {
   private case class Dirs(partitionPaths: Vector[(Path, Partition)]) extends StatusAccumulator
   private case object Files extends StatusAccumulator
 
-  private val PartitionRegexp: Regex = """([a-zA-Z0-9._]+)=([a-zA-Z0-9._]+)""".r
+  private[parquet4s] val PartitionRegexp: Regex = """([a-zA-Z0-9._]+)=([a-zA-Z0-9!\-_.*'()]+)""".r
 
   def makePath[F[_]](path: String)(implicit F: Sync[F]): F[Path] = F.delay(new Path(path))
 


### PR DESCRIPTION
Fix for #214 

With this change, the allowed characters for partition column values will be `!`, `-`, `_`, `.`, `*`, `'`, `(`, `)` plus the regular alphanumeric chars.

What I'm not sure about is if allowing all of these will cause other problems, so feedback is welcome!