### PR TITLE
fix: proper resolution of custom types

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -29,3 +29,6 @@ fileOverride {
     runner.dialect = scala3
   }
 }
+project.excludePaths = [
+  "glob:**/metals.sbt"
+]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -22,6 +22,9 @@ fileOverride {
   "glob:**/scala-2.12/**" {
     runner.dialect = scala212source3
   }
+  "glob:**/scala-2.13/**" {
+    runner.dialect = scala213source3
+  }
   "glob:**/scala-3/**" {
     runner.dialect = scala3
   }

--- a/core/src/it/scala-2.12/com/github/mjakubowski84/parquet4s/CustomTypeITSpec.scala
+++ b/core/src/it/scala-2.12/com/github/mjakubowski84/parquet4s/CustomTypeITSpec.scala
@@ -1,0 +1,127 @@
+package com.github.mjakubowski84.parquet4s
+
+import com.github.mjakubowski84.parquet4s.ParquetSchemaResolver.TypedSchemaDef
+import com.github.mjakubowski84.parquet4s.ValueImplicits.*
+import org.apache.parquet.schema.{LogicalTypeAnnotation, MessageType, PrimitiveType}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CustomTypeITSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with TestUtils {
+
+  object SimpleClass {
+    implicit val codec: ValueCodec[SimpleClass] = new RequiredValueCodec[SimpleClass] {
+      override protected def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): SimpleClass =
+        value match {
+          case BinaryValue(binary) => new SimpleClass(binary.toStringUsingUTF8)
+        }
+      override protected def encodeNonNull(data: SimpleClass, configuration: ValueCodecConfiguration): Value =
+        BinaryValue(data.value)
+    }
+    implicit val schema: TypedSchemaDef[SimpleClass] = SchemaDef
+      .primitive(
+        primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+        logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+      )
+      .typed[SimpleClass]
+  }
+  class SimpleClass(val value: String) {
+    override def hashCode(): Int = value.hashCode
+    override def equals(obj: Any): Boolean =
+      if (!obj.isInstanceOf[SimpleClass]) false
+      else this.value == (obj.asInstanceOf[SimpleClass].value)
+    override def toString: String = value
+  }
+
+  object CaseClass {
+    implicit val codec: ValueCodec[CaseClass] = new RequiredValueCodec[CaseClass] {
+      override protected def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): CaseClass =
+        value match {
+          case BinaryValue(binary) => CaseClass(binary.toStringUsingUTF8)
+        }
+      override protected def encodeNonNull(data: CaseClass, configuration: ValueCodecConfiguration): Value =
+        BinaryValue(data.value)
+    }
+    implicit val schema: TypedSchemaDef[CaseClass] = SchemaDef
+      .primitive(
+        primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+        logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+      )
+      .typed[CaseClass]
+  }
+  case class CaseClass(value: String)
+
+  object ComplexCaseClass {
+    implicit val codec: ValueCodec[ComplexCaseClass] = new RequiredValueCodec[ComplexCaseClass] {
+      override protected def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): ComplexCaseClass =
+        value match {
+          case record: RowParquetRecord =>
+            (record.get[String]("i", configuration), record.get[String]("j", configuration)) match {
+              case (Some(i), Some(j)) =>
+                ComplexCaseClass(i.toInt, j.toInt)
+              case _ =>
+                throw new RuntimeException("Invalid data for ComplexCaseClass")
+            }
+        }
+      override protected def encodeNonNull(data: ComplexCaseClass, configuration: ValueCodecConfiguration): Value =
+        RowParquetRecord("i" -> data.x.toString.value, "j" -> data.y.toString.value)
+    }
+    implicit val schema: TypedSchemaDef[ComplexCaseClass] = SchemaDef
+      .group(
+        SchemaDef.primitive(
+          primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+          logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+        )("i"),
+        SchemaDef.primitive(
+          primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+          logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+        )("j")
+      )
+      .typed[ComplexCaseClass]
+  }
+
+  case class ComplexCaseClass(x: Int, y: Int)
+
+  case class Data(a: SimpleClass, b: CaseClass, c: ComplexCaseClass)
+
+  val typed = Set(
+    Data(
+      new SimpleClass("simple"),
+      CaseClass("case"),
+      ComplexCaseClass(1, 2)
+    )
+  )
+  val generic = Set(
+    RowParquetRecord(
+      "a" -> "simple".value,
+      "b" -> "case".value,
+      "c" -> RowParquetRecord("i" -> "1".value, "j" -> "2".value)
+    )
+  )
+  val schema: MessageType = Message(None, SimpleClass.schema("a"), CaseClass.schema("b"), ComplexCaseClass.schema("c"))
+
+  before {
+    clearTemp()
+  }
+
+  "Custom types" should "be properly written" in {
+    // write
+    ParquetWriter.of[Data].writeAndClose(tempPath.append("test.parquet"), typed)
+
+    // read
+    val readData = ParquetReader.generic.read(tempPath)
+    try readData.toSet should be(generic)
+    finally readData.close()
+  }
+
+  it should "be properly read" in {
+    // write
+    ParquetWriter.generic(schema).writeAndClose(tempPath.append("test.parquet"), generic)
+
+    // read
+    val readData = ParquetReader.as[Data].read(tempPath)
+    try readData.toSet should be(typed)
+    finally readData.close()
+  }
+
+}

--- a/core/src/it/scala-2.13/com/github/mjakubowski84/parquet4s/CustomTypeITSpec.scala
+++ b/core/src/it/scala-2.13/com/github/mjakubowski84/parquet4s/CustomTypeITSpec.scala
@@ -1,0 +1,127 @@
+package com.github.mjakubowski84.parquet4s
+
+import com.github.mjakubowski84.parquet4s.ParquetSchemaResolver.TypedSchemaDef
+import com.github.mjakubowski84.parquet4s.ValueImplicits.*
+import org.apache.parquet.schema.{LogicalTypeAnnotation, MessageType, PrimitiveType}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CustomTypeITSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with TestUtils {
+
+  object SimpleClass {
+    implicit val codec: ValueCodec[SimpleClass] = new RequiredValueCodec[SimpleClass] {
+      override protected def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): SimpleClass =
+        value match {
+          case BinaryValue(binary) => new SimpleClass(binary.toStringUsingUTF8)
+        }
+      override protected def encodeNonNull(data: SimpleClass, configuration: ValueCodecConfiguration): Value =
+        BinaryValue(data.value)
+    }
+    implicit val schema: TypedSchemaDef[SimpleClass] = SchemaDef
+      .primitive(
+        primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+        logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+      )
+      .typed[SimpleClass]
+  }
+  class SimpleClass(val value: String) {
+    override def hashCode(): Int = value.hashCode
+    override def equals(obj: Any): Boolean =
+      if (!obj.isInstanceOf[SimpleClass]) false
+      else this.value == (obj.asInstanceOf[SimpleClass].value)
+    override def toString: String = value
+  }
+
+  object CaseClass {
+    implicit val codec: ValueCodec[CaseClass] = new RequiredValueCodec[CaseClass] {
+      override protected def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): CaseClass =
+        value match {
+          case BinaryValue(binary) => CaseClass(binary.toStringUsingUTF8)
+        }
+      override protected def encodeNonNull(data: CaseClass, configuration: ValueCodecConfiguration): Value =
+        BinaryValue(data.value)
+    }
+    implicit val schema: TypedSchemaDef[CaseClass] = SchemaDef
+      .primitive(
+        primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+        logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+      )
+      .typed[CaseClass]
+  }
+  case class CaseClass(value: String)
+
+  object ComplexCaseClass {
+    implicit val codec: ValueCodec[ComplexCaseClass] = new RequiredValueCodec[ComplexCaseClass] {
+      override protected def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): ComplexCaseClass =
+        value match {
+          case record: RowParquetRecord =>
+            (record.get[String]("i", configuration), record.get[String]("j", configuration)) match {
+              case (Some(i), Some(j)) =>
+                ComplexCaseClass(i.toInt, j.toInt)
+              case _ =>
+                throw new RuntimeException("Invalid data for ComplexCaseClass")
+            }
+        }
+      override protected def encodeNonNull(data: ComplexCaseClass, configuration: ValueCodecConfiguration): Value =
+        RowParquetRecord("i" -> data.x.toString.value, "j" -> data.y.toString.value)
+    }
+    implicit val schema: TypedSchemaDef[ComplexCaseClass] = SchemaDef
+      .group(
+        SchemaDef.primitive(
+          primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+          logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+        )("i"),
+        SchemaDef.primitive(
+          primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+          logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+        )("j")
+      )
+      .typed[ComplexCaseClass]
+  }
+
+  case class ComplexCaseClass(x: Int, y: Int)
+
+  case class Data(a: SimpleClass, b: CaseClass, c: ComplexCaseClass)
+
+  val typed = Set(
+    Data(
+      new SimpleClass("simple"),
+      CaseClass("case"),
+      ComplexCaseClass(1, 2)
+    )
+  )
+  val generic = Set(
+    RowParquetRecord(
+      "a" -> "simple".value,
+      "b" -> "case".value,
+      "c" -> RowParquetRecord("i" -> "1".value, "j" -> "2".value)
+    )
+  )
+  val schema: MessageType = Message(None, SimpleClass.schema("a"), CaseClass.schema("b"), ComplexCaseClass.schema("c"))
+
+  before {
+    clearTemp()
+  }
+
+  "Custom types" should "be properly written" in {
+    // write
+    ParquetWriter.of[Data].writeAndClose(tempPath.append("test.parquet"), typed)
+
+    // read
+    val readData = ParquetReader.generic.read(tempPath)
+    try readData.toSet should be(generic)
+    finally readData.close()
+  }
+
+  it should "be properly read" in {
+    // write
+    ParquetWriter.generic(schema).writeAndClose(tempPath.append("test.parquet"), generic)
+
+    // read
+    val readData = ParquetReader.as[Data].read(tempPath)
+    try readData.toSet should be(typed)
+    finally readData.close()
+  }
+
+}

--- a/core/src/it/scala-3/com/github/mjakubowski84/parquet4s/CustomTypeITSpec.scala
+++ b/core/src/it/scala-3/com/github/mjakubowski84/parquet4s/CustomTypeITSpec.scala
@@ -1,0 +1,130 @@
+package com.github.mjakubowski84.parquet4s
+
+import com.github.mjakubowski84.parquet4s.ParquetSchemaResolver.TypedSchemaDef
+import org.apache.parquet.schema.{LogicalTypeAnnotation, MessageType, PrimitiveType, Types}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import ValueImplicits.*
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY
+
+class CustomTypeITSpec extends AnyFlatSpec with Matchers with BeforeAndAfter with TestUtils:
+
+  object SimpleClass:
+    given RequiredValueCodec[SimpleClass] with
+      override protected def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): SimpleClass =
+        value match {
+          case BinaryValue(binary) => new SimpleClass(binary.toStringUsingUTF8)
+        }
+      override protected def encodeNonNull(data: SimpleClass, configuration: ValueCodecConfiguration): Value =
+        BinaryValue(data.value)
+
+    given schema: TypedSchemaDef[SimpleClass] = SchemaDef
+      .primitive(
+        primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+        logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+      )
+      .typed[SimpleClass]
+  end SimpleClass
+
+  class SimpleClass(val value: String):
+    override def hashCode(): Int = value.hashCode
+    override def equals(obj: Any): Boolean =
+      if (!obj.isInstanceOf[SimpleClass]) false
+      else this.value == obj.asInstanceOf[SimpleClass].value
+    override def toString: String = value
+  end SimpleClass
+
+  object CaseClass:
+    given RequiredValueCodec[CaseClass] with
+      override protected def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): CaseClass =
+        value match {
+          case BinaryValue(binary) => CaseClass(binary.toStringUsingUTF8)
+        }
+      override protected def encodeNonNull(data: CaseClass, configuration: ValueCodecConfiguration): Value =
+        BinaryValue(data.value)
+
+    given schema: TypedSchemaDef[CaseClass] = SchemaDef
+      .primitive(
+        primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+        logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+      )
+      .typed[CaseClass]
+  end CaseClass
+
+  case class CaseClass(value: String)
+
+  object ComplexCaseClass:
+    given RequiredValueCodec[ComplexCaseClass] with
+      override protected def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): ComplexCaseClass =
+        value match {
+          case record: RowParquetRecord =>
+            (record.get[String]("i", configuration), record.get[String]("j", configuration)) match {
+              case (Some(i), Some(j)) =>
+                ComplexCaseClass(i.toInt, j.toInt)
+              case _ =>
+                throw new RuntimeException("Invalid data for ComplexCaseClass")
+            }
+        }
+      override protected def encodeNonNull(data: ComplexCaseClass, configuration: ValueCodecConfiguration): Value =
+        RowParquetRecord("i" -> data.x.toString.value, "j" -> data.y.toString.value)
+
+    given schema: TypedSchemaDef[ComplexCaseClass] = SchemaDef
+      .group(
+        SchemaDef.primitive(
+          primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+          logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+        )("i"),
+        SchemaDef.primitive(
+          primitiveType         = PrimitiveType.PrimitiveTypeName.BINARY,
+          logicalTypeAnnotation = Option(LogicalTypeAnnotation.stringType())
+        )("j")
+      )
+      .typed[ComplexCaseClass]
+  end ComplexCaseClass
+
+  case class ComplexCaseClass(x: Int, y: Int)
+
+  case class Data(a: SimpleClass, b: CaseClass, c: ComplexCaseClass)
+
+  val typed = Set(
+    Data(
+      new SimpleClass("simple"),
+      CaseClass("case"),
+      ComplexCaseClass(1, 2)
+    )
+  )
+  val generic = Set(
+    RowParquetRecord(
+      "a" -> "simple".value,
+      "b" -> "case".value,
+      "c" -> RowParquetRecord("i" -> "1".value, "j" -> "2".value)
+    )
+  )
+  val schema: MessageType = Message(None, SimpleClass.schema("a"), CaseClass.schema("b"), ComplexCaseClass.schema("c"))
+
+  before {
+    clearTemp()
+  }
+
+  "Custom types" should "be properly written" in {
+    // write
+    ParquetWriter.of[Data].writeAndClose(tempPath.append("test.parquet"), typed)
+
+    // read
+    val readData = ParquetReader.generic.read(tempPath)
+    try readData.toSet should be(generic)
+    finally readData.close()
+  }
+
+  it should "be properly read" in {
+    // write
+    ParquetWriter.generic(schema).writeAndClose(tempPath.append("test.parquet"), generic)
+
+    // read
+    val readData = ParquetReader.as[Data].read(tempPath)
+    try readData.toSet should be(typed)
+    finally readData.close()
+  }
+
+end CustomTypeITSpec

--- a/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ProductDecoders.scala
+++ b/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ProductDecoders.scala
@@ -1,0 +1,16 @@
+package com.github.mjakubowski84.parquet4s
+
+import shapeless.LowPriority
+
+trait ProductDecoders {
+
+  implicit def productDecoder[T](implicit
+      ev: LowPriority,
+      decoder: ParquetRecordDecoder[T]
+  ): OptionalValueDecoder[T] =
+    (value, configuration) =>
+      value match {
+        case record: RowParquetRecord => decoder.decode(record, configuration)
+      }
+
+}

--- a/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ProductEncoders.scala
+++ b/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ProductEncoders.scala
@@ -1,0 +1,11 @@
+package com.github.mjakubowski84.parquet4s
+
+import shapeless.LowPriority
+
+trait ProductEncoders {
+  implicit def productEncoder[T](implicit
+      ev: LowPriority,
+      encoder: ParquetRecordEncoder[T]
+  ): OptionalValueEncoder[T] =
+    (data, configuration) => encoder.encode(data, null, configuration)
+}

--- a/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ProductSchemaDefs.scala
+++ b/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ProductSchemaDefs.scala
@@ -1,0 +1,13 @@
+package com.github.mjakubowski84.parquet4s
+
+import com.github.mjakubowski84.parquet4s.ParquetSchemaResolver.TypedSchemaDef
+import shapeless.LowPriority
+
+trait ProductSchemaDefs {
+  implicit def productSchema[T](implicit
+      ev: LowPriority,
+      parquetSchemaResolver: ParquetSchemaResolver[T]
+  ): TypedSchemaDef[T] =
+    SchemaDef.group(parquetSchemaResolver.resolveSchema(Cursor.simple)*).withMetadata(SchemaDef.Meta.Generated).typed[T]
+
+}

--- a/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/compat/CursorCompat.scala
+++ b/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/compat/CursorCompat.scala
@@ -1,5 +1,6 @@
-package com.github.mjakubowski84.parquet4s
+package com.github.mjakubowski84.parquet4s.compat
 
+import com.github.mjakubowski84.parquet4s.Cursor
 import shapeless.Witness
 
 trait CursorCompat {

--- a/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/compat/MapCompat.scala
+++ b/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/compat/MapCompat.scala
@@ -1,4 +1,6 @@
-package com.github.mjakubowski84.parquet4s
+package com.github.mjakubowski84.parquet4s.compat
+
+import com.github.mjakubowski84.parquet4s.{MapParquetRecord, Value}
 
 object MapCompat {
   @inline

--- a/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ProductDecoders.scala
+++ b/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ProductDecoders.scala
@@ -1,0 +1,16 @@
+package com.github.mjakubowski84.parquet4s
+
+import shapeless.LowPriority
+
+trait ProductDecoders {
+
+  implicit def productDecoder[T](implicit
+      ev: LowPriority,
+      decoder: ParquetRecordDecoder[T]
+  ): OptionalValueDecoder[T] =
+    (value, configuration) =>
+      value match {
+        case record: RowParquetRecord => decoder.decode(record, configuration)
+      }
+
+}

--- a/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ProductEncoders.scala
+++ b/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ProductEncoders.scala
@@ -1,0 +1,11 @@
+package com.github.mjakubowski84.parquet4s
+
+import shapeless.LowPriority
+
+trait ProductEncoders {
+  implicit def productEncoder[T](implicit
+      ev: LowPriority,
+      encoder: ParquetRecordEncoder[T]
+  ): OptionalValueEncoder[T] =
+    (data, configuration) => encoder.encode(data, null, configuration)
+}

--- a/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ProductSchemaDefs.scala
+++ b/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ProductSchemaDefs.scala
@@ -1,0 +1,13 @@
+package com.github.mjakubowski84.parquet4s
+
+import com.github.mjakubowski84.parquet4s.ParquetSchemaResolver.TypedSchemaDef
+import shapeless.LowPriority
+
+trait ProductSchemaDefs {
+  implicit def productSchema[T](implicit
+      ev: LowPriority,
+      parquetSchemaResolver: ParquetSchemaResolver[T]
+  ): TypedSchemaDef[T] =
+    SchemaDef.group(parquetSchemaResolver.resolveSchema(Cursor.simple)*).withMetadata(SchemaDef.Meta.Generated).typed[T]
+
+}

--- a/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/compat/CursorCompat.scala
+++ b/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/compat/CursorCompat.scala
@@ -1,5 +1,6 @@
-package com.github.mjakubowski84.parquet4s
+package com.github.mjakubowski84.parquet4s.compat
 
+import com.github.mjakubowski84.parquet4s.Cursor
 import shapeless.Witness
 
 trait CursorCompat {

--- a/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/compat/MapCompat.scala
+++ b/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/compat/MapCompat.scala
@@ -1,7 +1,10 @@
-package com.github.mjakubowski84.parquet4s
+package com.github.mjakubowski84.parquet4s.compat
+
+import com.github.mjakubowski84.parquet4s.{MapParquetRecord, Value}
 
 object MapCompat {
-  inline def remove[K, V](map: Map[K, V], key: K): Map[K, V] = map.removed(key)
+  @inline
+  def remove[K, V](map: Map[K, V], key: K): Map[K, V] = map.removed(key)
 }
 
 trait MapCompat {

--- a/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ProductDecoders.scala
+++ b/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ProductDecoders.scala
@@ -1,0 +1,16 @@
+package com.github.mjakubowski84.parquet4s
+
+import scala.util.NotGiven
+
+trait ProductDecoders:
+
+  given productDecoder[T](using
+      ev: NotGiven[ValueDecoder[T]],
+      decoder: ParquetRecordDecoder[T]
+  ): OptionalValueDecoder[T] =
+    (value, configuration) =>
+      value match {
+        case record: RowParquetRecord => decoder.decode(record, configuration)
+      }
+
+end ProductDecoders

--- a/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ProductEncoders.scala
+++ b/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ProductEncoders.scala
@@ -1,0 +1,13 @@
+package com.github.mjakubowski84.parquet4s
+
+import scala.util.NotGiven
+
+trait ProductEncoders:
+
+  given productEncoder[T](using
+      ev: NotGiven[ValueEncoder[T]],
+      encoder: ParquetRecordEncoder[T]
+  ): OptionalValueEncoder[T] =
+    (data, configuration) => encoder.encode(data, null, configuration)
+
+end ProductEncoders

--- a/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ProductSchemaDefs.scala
+++ b/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ProductSchemaDefs.scala
@@ -1,0 +1,18 @@
+package com.github.mjakubowski84.parquet4s
+
+import com.github.mjakubowski84.parquet4s.ParquetSchemaResolver.TypedSchemaDef
+
+import scala.reflect.{ClassTag, classTag}
+import scala.util.NotGiven
+
+trait ProductSchemaDefs:
+
+  given productSchema[T <: Product: ParquetSchemaResolver](using
+      NotGiven[TypedSchemaDef[T]]
+  ): TypedSchemaDef[T] =
+    SchemaDef
+      .group(summon[ParquetSchemaResolver[T]].resolveSchema(Cursor.simple)*)
+      .withMetadata(SchemaDef.Meta.Generated)
+      .typed[T]
+
+end ProductSchemaDefs

--- a/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/compat/CursorCompat.scala
+++ b/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/compat/CursorCompat.scala
@@ -1,6 +1,8 @@
-package com.github.mjakubowski84.parquet4s
+package com.github.mjakubowski84.parquet4s.compat
 
-trait CursorCompat {
+import com.github.mjakubowski84.parquet4s.Cursor
+
+trait CursorCompat:
 
   this: Cursor =>
 
@@ -12,4 +14,4 @@ trait CursorCompat {
   def advance[FieldName <: String & Singleton: ValueOf]: Option[Cursor] =
     advanceByFieldName(summon[ValueOf[FieldName]].value)
 
-}
+end CursorCompat

--- a/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/compat/MapCompat.scala
+++ b/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/compat/MapCompat.scala
@@ -1,11 +1,11 @@
-package com.github.mjakubowski84.parquet4s
+package com.github.mjakubowski84.parquet4s.compat
 
-object MapCompat {
-  @inline
-  def remove[K, V](map: Map[K, V], key: K): Map[K, V] = map.removed(key)
-}
+import com.github.mjakubowski84.parquet4s.{MapParquetRecord, Value}
 
-trait MapCompat {
+object MapCompat:
+  inline def remove[K, V](map: Map[K, V], key: K): Map[K, V] = map.removed(key)
+
+trait MapCompat:
 
   this: MapParquetRecord =>
 
@@ -31,4 +31,4 @@ trait MapCompat {
   override def updated[V1 >: Value](key: Value, value: V1): Map[Value, V1] =
     entries.updated(key, value)
 
-}
+end MapCompat

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ColumnPath.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ColumnPath.scala
@@ -95,7 +95,7 @@ class TypedColumnPath[T] private (elements: Seq[String], val alias: Option[Strin
       case head :: Nil =>
         leafSchema.apply(head)
       case head :: tail =>
-        GroupSchemaDef(Seq(toType(tail, leafSchema)), required = false).apply(head)
+        SchemaDef.group(toType(tail, leafSchema)).apply(head)
     }
 
   /** Sets an alias for this column path. Alias changes the name of the column during reading.

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/Cursor.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/Cursor.scala
@@ -1,5 +1,7 @@
 package com.github.mjakubowski84.parquet4s
 
+import com.github.mjakubowski84.parquet4s.compat.CursorCompat
+
 /** Auxiliary construct that facilitates traversal over tree of case classes. Apart from pointing if program should
   * advance the tree it implements visitor pattern that allows to process the content of the tree in context of cursor's
   * state.

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetIterable.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetIterable.scala
@@ -131,7 +131,7 @@ trait ParquetIterable[T] extends Iterable[T] with Closeable {
     * @return
     *   min value or [[scala.None]] if there is no matching data or path is invalid
     */
-  def min[V: Ordering: ValueDecoder](columnPath: ColumnPath): Option[V] = stats.min(columnPath)
+  def min[V: Ordering: ValueDecoder](columnPath: ColumnPath): Option[V] = stats.min[V](columnPath)
 
   /** Returns max value of underlying dataset at given path
     *
@@ -142,7 +142,7 @@ trait ParquetIterable[T] extends Iterable[T] with Closeable {
     * @return
     *   max value or [[scala.None]] if there is no matching data or path is invalid
     */
-  def max[V: Ordering: ValueDecoder](columnPath: ColumnPath): Option[V] = stats.max(columnPath)
+  def max[V: Ordering: ValueDecoder](columnPath: ColumnPath): Option[V] = stats.max[V](columnPath)
 
   /** Returns the size of the underlying dataset. Filter is considered during calculation. Tries to leverage Parquet
     * metadata and statistics in order to avoid full traverse over the dataset.

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
@@ -1,5 +1,6 @@
 package com.github.mjakubowski84.parquet4s
 
+import com.github.mjakubowski84.parquet4s.compat.MapCompat
 import org.apache.parquet.io.api.RecordConsumer
 import org.apache.parquet.schema.Type.Repetition
 import org.apache.parquet.schema.{GroupType, MessageType, Type}

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/Stats.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/Stats.scala
@@ -27,7 +27,7 @@ trait Stats {
     *   Minimum value across Parquet data. [[Filter]] is considered during calculation.
     */
   def min[V](columnPath: ColumnPath)(implicit decoder: ValueDecoder[V], ordering: Ordering[V]): Option[V] =
-    min(columnPath, None)
+    min[V](columnPath, None)
 
   /** @param columnPath
     *   [[ColumnPath]]
@@ -41,7 +41,7 @@ trait Stats {
     *   Maximum value across Parquet data. [[Filter]] is considered during calculation.
     */
   def max[V](columnPath: ColumnPath)(implicit decoder: ValueDecoder[V], ordering: Ordering[V]): Option[V] =
-    max(columnPath, None)
+    max[V](columnPath, None)
 
   protected[parquet4s] def min[V](columnPath: ColumnPath, currentMin: Option[V])(implicit
       decoder: ValueDecoder[V],

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ValueCodecs.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ValueCodecs.scala
@@ -4,9 +4,8 @@ import java.nio.{ByteBuffer, ByteOrder}
 import java.sql.{Date, Timestamp}
 import java.time.*
 import scala.collection.compat.*
-import scala.reflect.ClassTag
-
 import scala.language.higherKinds
+import scala.reflect.ClassTag
 
 trait PrimitiveValueDecoders {
 
@@ -250,7 +249,7 @@ trait TimeValueEncoders {
 
 }
 
-trait ComplexValueDecoders {
+trait ComplexValueDecoders extends ProductDecoders {
 
   implicit def collectionDecoder[T, Col[_]](implicit
       evidence: Col[T] <:< Iterable[T],
@@ -305,17 +304,9 @@ trait ComplexValueDecoders {
         }
     }
 
-  implicit def productDecoder[T](implicit decoder: ParquetRecordDecoder[T]): OptionalValueDecoder[T] =
-    new OptionalValueDecoder[T] {
-      def decodeNonNull(value: Value, configuration: ValueCodecConfiguration): T =
-        value match {
-          case record: RowParquetRecord => decoder.decode(record, configuration)
-        }
-    }
-
 }
 
-trait ComplexValueEncoders {
+trait ComplexValueEncoders extends ProductEncoders {
 
   implicit def collectionEncoder[T, Col[_]](implicit
       evidence: Col[T] <:< Iterable[T],
@@ -364,12 +355,6 @@ trait ComplexValueEncoders {
           require(key != null, "Map cannot have null keys")
           record.updated(key, value, configuration)
         }
-    }
-
-  implicit def productEncoder[T](implicit encoder: ParquetRecordEncoder[T]): OptionalValueEncoder[T] =
-    new OptionalValueEncoder[T] {
-      def encodeNonNull(data: T, configuration: ValueCodecConfiguration): Value =
-        encoder.encode(data, null, configuration)
     }
 
 }

--- a/project/DependecyVersions.scala
+++ b/project/DependecyVersions.scala
@@ -1,9 +1,9 @@
 object DependecyVersions {
   val parquetVersion   = "1.12.2"
   val shapelessVersion = "2.3.7"
-  val sparkVersion     = "3.2.0"
+  val sparkVersion     = "3.2.1"
   val hadoopVersion    = "3.3.1"
-  val slf4jVersion     = "1.7.32"
-  val akkaVersion      = "2.6.17"
+  val slf4jVersion     = "1.7.35"
+  val akkaVersion      = "2.6.18"
   val fs2Version       = "3.1.6"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.6.2

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -2,4 +2,4 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.11")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.release")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.5")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "1.3.4")
 
 libraryDependencies ++= Seq("com.47deg" %% "github4s" % "0.28.5")


### PR DESCRIPTION
1. Fixes resolution of implicit codecs and schemas for custom types provided by users of the library. Especially, allows using classes and case classes as a custom type - by giving higher priority to implicits provided by a user.
2. Custom schema is not processed by `ParquetSchemaResolver` during partitioning and its fields are not filtered (partition fields are nor removed) - user has to take partitioning into account when defining a schema.
3. Several minor library upgrades
4. Compatibility classes are moved to dedicated `compat` package