### PR TITLE
fix: handle case when getCanonicalName may throw an error

### DIFF
--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
@@ -412,7 +412,7 @@ final class RowParquetRecord private (
   override def toString: String =
     fields.iterator
       .map(name => s"$name=${values(name)}")
-      .mkString(getClass.getSimpleName + " (", ",", ")")
+      .mkString("RowParquetRecord(", ",", ")")
 
   /** Adds a new field to the front of the record.
     * @param name
@@ -616,7 +616,7 @@ final class ListParquetRecord private (private val values: Vector[Value])
 
   override def iterator: Iterator[Value] = values.iterator
 
-  override def toString: String = values.mkString("ListParquetRecord (", ",", ")")
+  override def toString: String = values.mkString("ListParquetRecord(", ",", ")")
 
   override def write(schema: Type, recordConsumer: RecordConsumer): Unit = {
     recordConsumer.startGroup()
@@ -800,7 +800,7 @@ final class MapParquetRecord private[parquet4s] (protected val entries: Map[Valu
   override def toString: String =
     entries
       .map { case (key, value) => s"$key=$value" }
-      .mkString(getClass.getSimpleName + " (", ",", ")")
+      .mkString("MapParquetRecord(", ",", ")")
 
   override def write(schema: Type, recordConsumer: RecordConsumer): Unit = {
     recordConsumer.startGroup()

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetSchemaResolverSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetSchemaResolverSpec.scala
@@ -1,13 +1,19 @@
 package com.github.mjakubowski84.parquet4s
 
-import com.github.mjakubowski84.parquet4s.LogicalTypes._
+import com.github.mjakubowski84.parquet4s.LogicalTypes.*
 import com.github.mjakubowski84.parquet4s.ParquetSchemaResolver.resolveSchema
-import com.github.mjakubowski84.parquet4s.TestCases._
-import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName._
-import org.apache.parquet.schema.Type.Repetition._
+import com.github.mjakubowski84.parquet4s.TestCases.*
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*
+import org.apache.parquet.schema.Type.Repetition.*
 import org.apache.parquet.schema.Types
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+object ParquetSchemaResolverSpec {
+  object Malformed {
+    case class Clazz()
+  }
+}
 
 class ParquetSchemaResolverSpec extends AnyFlatSpec with Matchers {
 
@@ -247,6 +253,20 @@ class ParquetSchemaResolverSpec extends AnyFlatSpec with Matchers {
           .named("nested")
       )
     )
+  }
+
+  it should "resolve schema name from class name" in {
+    resolveSchema[Empty].getName should be("com.github.mjakubowski84.parquet4s.TestCases.Empty")
+  }
+
+  it should "use default schema name when fails to resolve a class name" in {
+    case class Clazz()
+    resolveSchema[Clazz].getName should be(Message.DefaultName)
+  }
+
+  it should "use default schema name when processing a class that JVM treats as malformed" in {
+    val resolved = resolveSchema[ParquetSchemaResolverSpec.Malformed.Clazz]
+    resolved.getName should be(Message.DefaultName)
   }
 
 }


### PR DESCRIPTION
In some JVMs (some distributions of Java 8) `getSimpleName` or `getCanonicalName` may fail with an exception when resolving a deeply nested Scala class. Let's catch this exception.