### PR TITLE
Add `$` to list of allowed chars in partition value

### DIFF
--- a/akka/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
+++ b/akka/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
@@ -19,7 +19,7 @@ private[parquet4s] object IOOps {
 
   private type Partition = (ColumnPath, String)
 
-  private[parquet4s] val PartitionRegexp: Regex = """([a-zA-Z0-9._]+)=([a-zA-Z0-9!\-_.*'()]+)""".r
+  private[parquet4s] val PartitionRegexp: Regex = """([a-zA-Z0-9._]+)=([a-zA-Z0-9!\-_.*'()$]+)""".r
 
 }
 

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/PartitionTestUtils.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/PartitionTestUtils.scala
@@ -6,8 +6,9 @@ trait PartitionTestUtils extends TableDrivenPropertyChecks {
   private val allChars: Seq[Char]          = (Byte.MinValue to Byte.MaxValue).map(_.toChar)
   private val alphaNumericChars: Seq[Char] = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
 
-  private val allowedPartitionNameChars: Seq[Char]  = alphaNumericChars ++ Seq('.', '_')
-  private val allowedPartitionValueChars: Seq[Char] = alphaNumericChars ++ Seq('!', '-', '_', '.', '*', '\'', '(', ')')
+  private val allowedPartitionNameChars: Seq[Char] = alphaNumericChars ++ Seq('.', '_')
+  private val allowedPartitionValueChars: Seq[Char] =
+    alphaNumericChars ++ Seq('!', '-', '_', '.', '*', '\'', '(', ')', '$')
 
   private val disallowedPartitionNameChars: Seq[Char]  = allChars.filterNot(allowedPartitionNameChars.contains)
   private val disallowedPartitionValueChars: Seq[Char] = allChars.filterNot(allowedPartitionValueChars.contains)

--- a/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/io.scala
+++ b/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/io.scala
@@ -25,7 +25,7 @@ private[parquet] object io {
   private case class Dirs(partitionPaths: Vector[(Path, Partition)]) extends StatusAccumulator
   private case object Files extends StatusAccumulator
 
-  private[parquet4s] val PartitionRegexp: Regex = """([a-zA-Z0-9._]+)=([a-zA-Z0-9!\-_.*'()]+)""".r
+  private[parquet4s] val PartitionRegexp: Regex = """([a-zA-Z0-9._]+)=([a-zA-Z0-9!\-_.*'()$]+)""".r
 
   def validateWritePath[F[_]](path: Path, writeOptions: ParquetWriter.Options, logger: Logger[F])(implicit
       F: Sync[F]


### PR DESCRIPTION
This PR is being proposed in response to https://github.com/mjakubowski84/parquet4s/issues/260.

There are real-world use-cases with partition directory values that have a `$` character in them. For example:
```
raw
├── env=ENV1-PROD
│   ├── tenant=123abc
│   │   └── task_id=do_stuff
│   │       ├── part-00000-c-1272915f5d4d.c000.snappy.parquet
    ...
│   ├── tenant=samirb
│   │   ├── task_id=2a7$275_56$29xyz
│   │   │   ├── part-00000-d-1272915f5d4d.c000.snappy.parquet
```

This change accommodates names like those shown above. Note that the change only allows `$` in the value portion of the directory name.

Existing test cases cover this new addition to the list of allowed partition value characters.