### PR TITLE
Fix #285: Avoid wrapping FileSystem with Resource

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,8 +94,8 @@ lazy val core = (project in file("core"))
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
 
       // tests
-      "org.mockito" % "mockito-core" % "4.8.0" % "test",
-      "org.scalatest" %% "scalatest" % "3.2.14" % "test,it",
+      "org.mockito" % "mockito-core" % mockitoVersion % "test",
+      "org.scalatest" %% "scalatest" % scalatestVersion % "test,it",
       "ch.qos.logback" % "logback-classic" % logbackVersion % "test,it",
       "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % "test,it"
     ) ++ {
@@ -152,7 +152,24 @@ lazy val fs2 = (project in file("fs2"))
   .settings(itSettings)
   .settings(publishSettings)
   .settings(testReportSettings)
-  .dependsOn(core % "compile->compile;test->test")
+  .dependsOn(core % "compile->compile;test->test", testkit % "it->compile")
+
+lazy val testkit = (project in file("testkit"))
+  .settings(
+    name := "parquet4s-testkit",
+    crossScalaVersions := supportedScalaVersions,
+    publish / skip := true,
+    publishLocal / skip := true,
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % scalatestVersion,
+      "org.apache.hadoop" % "hadoop-minicluster" % hadoopVersion,
+      // MiniDFSCluster leaks Mockito via NameNodeAdapter while hadoop-minicluster doesn't bring
+      // the dependency transitively. We have to add it explicitly to prevent ClassNotFoundException.
+      "org.mockito" % "mockito-core" % mockitoVersion,
+      "org.slf4j" % "log4j-over-slf4j" % slf4jVersion,
+      "ch.qos.logback" % "logback-classic" % logbackVersion
+    )
+  )
 
 lazy val examples = (project in file("examples"))
   .settings(
@@ -278,6 +295,7 @@ lazy val root = (project in file("."))
     core,
     akka,
     fs2,
+    testkit,
     examples,
     coreBenchmarks,
     akkaBenchmarks,

--- a/fs2/src/it/resources/logback-test.xml
+++ b/fs2/src/it/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.github.mjakubowski84.parquet4s" level="DEBUG"/>
+    <logger name="org.apache.parquet" level="WARN"/>
+    <!-- Configure Hadoop minicluster-related logs -->
+    <logger name="org.apache.hadoop.hdfs.MiniDFSCluster" level="INFO"/>
+    <logger name="org.apache.hadoop" level="WARN"/>
+    <logger name="org.apache.hadoop.hdfs" level="ERROR"/>
+    <logger name="org.apache.hadoop.http" level="ERROR"/>
+    <logger name="org.apache.hadoop.security" level="ERROR"/>
+    <logger name="org.apache.hadoop.metrics2" level="ERROR"/>
+    <logger name="BlockStateChange" level="WARN"/>
+    <logger name="org.eclipse.jetty" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/fs2/src/it/scala/com/github/mjakubowski84/parquet4s/Fs2ParquetDfsItSpec.scala
+++ b/fs2/src/it/scala/com/github/mjakubowski84/parquet4s/Fs2ParquetDfsItSpec.scala
@@ -1,0 +1,56 @@
+package com.github.mjakubowski84.parquet4s
+
+import cats.effect.IO
+import cats.effect.std.UUIDGen
+import cats.effect.testing.scalatest.AsyncIOSpec
+import com.github.mjakubowski84.parquet4s.Fs2ParquetDfsItSpec.Data
+import com.github.mjakubowski84.parquet4s.testkit.ForAllMiniDfsCluster
+import fs2.{Pipe, Stream}
+import org.scalatest.flatspec.AsyncFlatSpec
+
+import scala.collection.compat.immutable.LazyList
+
+object Fs2ParquetDfsItSpec {
+  case class Data(i: Long)
+}
+
+class Fs2ParquetDfsItSpec extends AsyncFlatSpec with AsyncIOSpec with ForAllMiniDfsCluster {
+  private lazy val readOptions  = ParquetReader.Options(hadoopConf = hadoopConfiguration)
+  private lazy val writeOptions = ParquetWriter.Options(hadoopConf = hadoopConfiguration)
+
+  override protected val deleteDfsDirOnShutdown: Boolean = true
+
+  behavior of "parquet4s-fs2"
+
+  it should "concurrently read and write files" in {
+    val program = for {
+      // Given
+      inPath  <- UUIDGen.randomUUID[IO].map(id => Path(s"/$id.parquet"))
+      outPath <- UUIDGen.randomUUID[IO].map(id => Path(s"/$id.parquet"))
+      _       <- Stream.iterable(makeTestData()).through(writeData(inPath)).compile.drain
+      // When
+      _ <- readData(inPath).map(d => d.copy(i = d.i + 1)).through(writeData(outPath)).compile.drain
+    } yield ()
+    // Then
+    program.assertNoException
+  }
+
+  // Helpers
+
+  private def readData(path: Path): Stream[IO, Data] =
+    parquet
+      .fromParquet[IO]
+      .as[Data]
+      .options(readOptions)
+      .read(path)
+
+  private def writeData(path: Path): Pipe[IO, Data, Nothing] =
+    parquet
+      .writeSingleFile[IO]
+      .of[Data]
+      .options(writeOptions)
+      .write(path)
+
+  private def makeTestData(): LazyList[Data] =
+    LazyList.range(start = 0L, end = 1024L, step = 1L).map(Data.apply)
+}

--- a/project/DependecyVersions.scala
+++ b/project/DependecyVersions.scala
@@ -9,4 +9,6 @@ object DependecyVersions {
   val fs2Version                   = "3.4.0"
   val catsEffectVersion            = "3.4.2"
   val scalaCollectionCompatVersion = "2.9.0"
+  val scalatestVersion             = "3.2.14"
+  val mockitoVersion               = "4.8.0"
 }

--- a/testkit/src/main/scala/com/github/mjakubowski84/parquet4s/testkit/ForAllMiniDfsCluster.scala
+++ b/testkit/src/main/scala/com/github/mjakubowski84/parquet4s/testkit/ForAllMiniDfsCluster.scala
@@ -1,0 +1,32 @@
+package com.github.mjakubowski84.parquet4s.testkit
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hdfs.MiniDFSCluster
+import org.scalatest.{Args, CompositeStatus, Status, Suite, SuiteMixin}
+
+import java.nio.file.Files
+
+trait ForAllMiniDfsCluster extends SuiteMixin {
+  self: Suite =>
+
+  private lazy val cluster = {
+    val baseDir       = Files.createTempDirectory("").toFile
+    val configuration = new Configuration()
+    new MiniDFSCluster.Builder(configuration, baseDir).format(true).build
+  }
+
+  protected val deleteDfsDirOnShutdown: Boolean
+
+  def hadoopConfiguration: Configuration =
+    cluster.getConfiguration(0)
+
+  abstract override def run(testName: Option[String], args: Args): Status =
+    if (expectedTestCount(args.filter) == 0) {
+      new CompositeStatus(Set.empty)
+    } else {
+      try {
+        cluster // run cluster
+        super.run(testName, args)
+      } finally cluster.shutdown(deleteDfsDirOnShutdown)
+    }
+}


### PR DESCRIPTION
I see the same FileSystem closing pattern inside the `com.github.mjakubowski84.parquet4s.IOOps`. Probably, we should apply the same fix to `IOOps`. Current PR focuses on fixing parquet4s-fs2.