### PR TITLE
Fix #285: Avoid closing FileSystem in parquet4s-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,7 @@ lazy val testReportSettings = Project.inConfig(Test)(
 lazy val sparkDeps = Seq(
   "org.apache.spark" %% "spark-core" % sparkVersion % "it"
     exclude (org = "org.apache.hadoop", name = "hadoop-client")
+    exclude (org = "org.apache.hadoop", name = "hadoop-client-api")
     exclude (org = "org.slf4j", name = "slf4j-api")
     exclude (org = "org.apache.parquet", name = "parquet-hadoop"),
   "org.apache.spark" %% "spark-sql" % sparkVersion % "it"
@@ -112,6 +113,7 @@ lazy val core = (project in file("core"))
   .settings(itSettings)
   .settings(publishSettings)
   .settings(testReportSettings)
+  .dependsOn(testkit % "it->compile")
 
 lazy val akka = (project in file("akka"))
   .configs(IntegrationTest)

--- a/core/src/it/resources/logback-test.xml
+++ b/core/src/it/resources/logback-test.xml
@@ -11,6 +11,14 @@
     <logger name="org.sparkproject.jetty" level="WARN"/>
     <logger name="org.apache.hadoop" level="WARN"/>
     <logger name="org.apache.htrace" level="WARN"/>
+    <!-- Configure Hadoop minicluster-related logs -->
+    <logger name="org.apache.hadoop.hdfs.MiniDFSCluster" level="INFO"/>
+    <logger name="org.apache.hadoop.hdfs" level="ERROR"/>
+    <logger name="org.apache.hadoop.http" level="ERROR"/>
+    <logger name="org.apache.hadoop.security" level="ERROR"/>
+    <logger name="org.apache.hadoop.metrics2" level="ERROR"/>
+    <logger name="BlockStateChange" level="WARN"/>
+    <logger name="org.eclipse.jetty" level="WARN"/>
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetDfsItSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetDfsItSpec.scala
@@ -1,0 +1,43 @@
+package com.github.mjakubowski84.parquet4s
+
+import com.github.mjakubowski84.parquet4s.ParquetDfsItSpec.Data
+import com.github.mjakubowski84.parquet4s.testkit.ForAllMiniDfsCluster
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.util.UUID
+
+object ParquetDfsItSpec {
+  case class Data(i: Long)
+}
+
+class ParquetDfsItSpec extends AnyFlatSpec with ForAllMiniDfsCluster {
+  private lazy val readOptions  = ParquetReader.Options(hadoopConf = hadoopConfiguration)
+  private lazy val writeOptions = ParquetWriter.Options(hadoopConf = hadoopConfiguration)
+
+  override protected val deleteDfsDirOnShutdown: Boolean = true
+
+  behavior of "parquet4s-core"
+
+  it should "concurrently read and write files" in {
+    // Given
+    val inPath  = Path(s"/${UUID.randomUUID()}.parquet")
+    val outPath = Path(s"/${UUID.randomUUID()}.parquet")
+    ParquetWriter.of[Data].options(writeOptions).writeAndClose(inPath, makeTestData())
+    // When
+    val outWriter  = ParquetWriter.of[Data].options(writeOptions).build(outPath)
+    val inIterable = ParquetReader.as[Data].options(readOptions).partitioned.read(inPath)
+
+    try outWriter.write(inIterable.map(d => d.copy(i = d.i + 1)))
+    finally {
+      inIterable.close()
+      outWriter.close()
+    }
+    // Then
+    succeed
+  }
+
+  // Helpers
+
+  private def makeTestData(): Iterable[Data] =
+    (1L to 1024L).map(Data.apply)
+}


### PR DESCRIPTION
As far as I can see, parquet4s-akka relies on `IOOps`, so there is no need to fix anything in parquet4s-akka. Hence, this PR touches only parquet4s-core.

Fixes #285.