### PR TITLE
Add support for various legacy containers

### DIFF
--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetRecord.scala
@@ -507,13 +507,13 @@ final class RowParquetRecord private (
 
 object ListParquetRecord {
   object ElementName {
-    val Element = "element"
-    val Array = "array"
+    val Element      = "element"
+    val Array        = "array"
     val ArrayElement = "array_element"
   }
 
-  private val ListFieldName          = "list"
-  private val ElementNames           = Set(ElementName.Element, ElementName.Array, ElementName.ArrayElement)
+  private val ListFieldName = "list"
+  private val ElementNames  = Set(ElementName.Element, ElementName.Array, ElementName.ArrayElement)
 
   /** @param elements
     *   to init the record with
@@ -628,12 +628,12 @@ final class ListParquetRecord private (private val values: Vector[Value])
     if (values.nonEmpty) {
       val groupSchema = schema.asGroupType()
 
-      val container = groupSchema.getFields.get(0).asGroupType()
-      val fieldName = container.getName
+      val container   = groupSchema.getFields.get(0).asGroupType()
+      val fieldName   = container.getName
       val elementName = container.getFields.get(0).getName
 
-      val listSchema  = groupSchema.getType(fieldName).asGroupType()
-      val listIndex   = groupSchema.getFieldIndex(fieldName)
+      val listSchema = groupSchema.getType(fieldName).asGroupType()
+      val listIndex  = groupSchema.getFieldIndex(fieldName)
 
       recordConsumer.startField(fieldName, listIndex)
 

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetRecordSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetRecordSpec.scala
@@ -194,6 +194,15 @@ class ParquetRecordSpec extends AnyFlatSpec with Matchers with Inspectors {
     lst should contain theSameElementsInOrderAs Seq(b1, b2)
   }
 
+  it should "accumulate 3-levels legacy primitive values with array_element" in {
+    val b1  = "a string".value
+    val b2  = "another string".value
+    val r1  = RowParquetRecord("array_element" -> b1)
+    val r2  = RowParquetRecord("array_element" -> b2)
+    val lst = ListParquetRecord.Empty.add("bag", r1).add("bag", r2)
+    lst should contain theSameElementsInOrderAs Seq(b1, b2)
+  }
+
   it should "accumulate legacy compound values" in {
     val r1  = RowParquetRecord("a" -> 1.value, "b" -> 2.value)
     val r2  = RowParquetRecord("c" -> 3.value, "d" -> 4.value)


### PR DESCRIPTION
I have encountered the following in the wild with some old python pandas version:

```thrift
optional group column_name (LIST) {
  repeated group bag {
    optional binary array_element (STRING);
  }
}
```

So I added support for

```thrift
optional group column_name (LIST) {
  repeated group bag/list {
    optional binary array/element/array_element (STRING);
  }
}
```

it should actually support


```thrift
optional group column_name (LIST) {
  repeated group * {
    optional binary * (STRING);
  }
}
```


