### PR TITLE
Add error logs to identify failure of findPartitionedPaths function

### DIFF
--- a/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/reader.scala
+++ b/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/reader.scala
@@ -145,7 +145,8 @@ object reader {
     for {
       vcc <- Stream(ValueCodecConfiguration(options))
       decode = (record: RowParquetRecord) => F.delay(ParquetRecordDecoder.decode(record, vcc))
-      partitionedDirectory <- io.findPartitionedPaths(basePath, options.hadoopConf)
+      logger               <- Stream.eval(logger[F](this.getClass))
+      partitionedDirectory <- io.findPartitionedPaths(basePath, options.hadoopConf, logger)
       projectedSchemaOpt <- Stream.eval(
         projectedSchemaResolverOpt
           .traverse(implicit resolver =>


### PR DESCRIPTION
- To help debug errors (specially helpful when using Hadoop S3 connector)