### PR TITLE
support for writing to in-memory output file

### DIFF
--- a/akka/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetPartitioningFlow.scala
+++ b/akka/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetPartitioningFlow.scala
@@ -304,7 +304,7 @@ private class ParquetPartitioningFlow[T, W](
               logger.debug("Creating writer to write to [{}]", writerPath)
 
               val writer = ParquetWriter.internalWriter(
-                path    = Path(writerPath, newFileName),
+                file    = Path(writerPath, newFileName).toOutputFile(writeOptions),
                 schema  = schema,
                 options = writeOptions
               )

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/InMemoryInputFile.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/InMemoryInputFile.scala
@@ -1,0 +1,64 @@
+package com.github.mjakubowski84.parquet4s
+
+import org.apache.parquet.io.{InputFile, SeekableInputStream}
+
+import java.io.EOFException
+import java.nio.ByteBuffer
+import scala.util.control.NoStackTrace
+
+object InMemoryInputFile {
+  def fromBytesUnsafe(bytes: Array[Byte]): InMemoryInputFile = new InMemoryInputFile(bytes)
+
+  def fromBytes(bytes: Array[Byte]): InMemoryInputFile = new InMemoryInputFile(bytes.clone())
+}
+
+class InMemoryInputFile private (content: Array[Byte]) extends InputFile {
+
+  override def getLength: Long = content.length
+
+  override def newStream(): SeekableInputStream = new SeekableInputStream {
+    private var pos: Int = 0
+
+    override def getPos: Long = pos
+
+    override def seek(newPos: Long): Unit = pos = newPos.toInt
+
+    override def readFully(bytes: Array[Byte]): Unit = readFully(bytes, 0, bytes.length)
+
+    override def readFully(bytes: Array[Byte], start: Int, len: Int): Unit = {
+      if (content.length - pos < len) throw new EOFException with NoStackTrace
+      System.arraycopy(content, pos, bytes, start, len)
+      pos += len
+    }
+
+    override def read(buf: ByteBuffer): Int = {
+      val avail = remaining
+      if (avail == 0) -1
+      else {
+        val len = avail.min(buf.remaining())
+        if (len > 0) {
+          buf.put(content, pos, len)
+          pos += len
+        }
+        len
+      }
+    }
+
+    override def readFully(buf: ByteBuffer): Unit = {
+      val availSpace = buf.remaining
+      if (remaining < availSpace) throw new EOFException with NoStackTrace
+      if (availSpace > 0) buf.put(content, pos, availSpace)
+      pos += availSpace
+    }
+
+    override def read(): Int =
+      if (remaining == 0) -1
+      else {
+        val next = content(pos).toInt
+        pos += 1
+        next
+      }
+
+    private def remaining: Int = content.length - pos
+  }
+}

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/InMemoryOutputFile.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/InMemoryOutputFile.scala
@@ -1,0 +1,37 @@
+package com.github.mjakubowski84.parquet4s
+
+import org.apache.hadoop.fs.FileAlreadyExistsException
+import org.apache.parquet.io.{OutputFile, PositionOutputStream}
+
+import java.io.ByteArrayOutputStream
+import scala.language.reflectiveCalls
+import scala.util.control.NoStackTrace
+
+object InMemoryOutputFile {
+  def create(name: String): InMemoryOutputFile = new InMemoryOutputFile(name)
+}
+
+class InMemoryOutputFile(name: String) extends OutputFile {
+  private val os = new ByteArrayOutputStream()
+
+  override def create(blockSizeHint: Long): PositionOutputStream = {
+    if (os.size() > 0) throw new FileAlreadyExistsException(s"In-memory file already exists: $name")
+    new PositionOutputStream {
+      override def getPos: Long                                    = os.size()
+      override def write(b: Int): Unit                             = os.write(b)
+      override def write(b: Array[Byte], off: Int, len: Int): Unit = os.write(b, off, len)
+    }
+  }
+
+  override def createOrOverwrite(blockSizeHint: Long): PositionOutputStream = {
+    os.reset()
+    create(blockSizeHint)
+  }
+
+  override def supportsBlockSize(): Boolean = false
+
+  override def defaultBlockSize(): Long =
+    throw new UnsupportedOperationException("Block size is not supported by InMemoryOutputFile") with NoStackTrace
+
+  def toByteArray(): Array[Byte] = os.toByteArray
+}

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
@@ -107,12 +107,16 @@ object ParquetWriter {
       */
     def options(options: Options): Builder[T]
 
-    /** Builds a writer for writing files to given path.
+    /** Builds a writer for writing the output file
       */
+    @experimental
     def build(file: OutputFile): ParquetWriter[T]
 
     def build(path: Path): ParquetWriter[T]
 
+    /** Writes iterable collection of data as a Parquet output file.
+      */
+    @experimental
     def writeAndClose(file: OutputFile, data: Iterable[T]): Unit
 
     /** Writes iterable collection of data as a Parquet files at given path.

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/Path.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/Path.scala
@@ -1,6 +1,10 @@
 package com.github.mjakubowski84.parquet4s
 
+import com.github.mjakubowski84.parquet4s.ParquetWriter.Options
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path as HadoopPath
+import org.apache.parquet.hadoop.util.HadoopOutputFile
+import org.apache.parquet.io.OutputFile
 
 import java.net.URI
 import java.nio.file.{Paths, Path as NioPath}
@@ -36,6 +40,10 @@ class Path private (val hadoopPath: HadoopPath) {
   def toHadoop: HadoopPath = hadoopPath
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[Path]
+
+  def toOutputFile(conf: Configuration): OutputFile = HadoopOutputFile.fromPath(hadoopPath, conf)
+
+  def toOutputFile(options: Options): OutputFile = toOutputFile(options.hadoopConf)
 
   override def equals(other: Any): Boolean = other match {
     case that: Path =>

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/FileStats.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/FileStats.scala
@@ -7,21 +7,30 @@ import org.apache.parquet.ParquetReadOptions
 import org.apache.parquet.column.statistics.Statistics
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.util.HadoopInputFile
+import org.apache.parquet.io.InputFile
 import org.apache.parquet.schema.MessageType
 
 import scala.collection.compat.*
 import scala.jdk.CollectionConverters.*
 
+private[parquet4s] object FileStats {
+  def apply(
+      status: FileStatus,
+      vcc: ValueCodecConfiguration,
+      hadoopConf: Configuration,
+      projectionSchemaOpt: Option[MessageType]
+  ) =
+    new FileStats(HadoopInputFile.fromStatus(status, hadoopConf), vcc, projectionSchemaOpt)
+}
+
 /** Calculates statistics from <b>unfiltered</b> Parquet files.
   */
 private[parquet4s] class FileStats(
-    status: FileStatus,
+    inputFile: InputFile,
     vcc: ValueCodecConfiguration,
-    hadoopConf: Configuration,
     projectionSchemaOpt: Option[MessageType]
 ) extends Stats {
 
-  private val inputFile     = HadoopInputFile.fromStatus(status, hadoopConf)
   private val readerOptions = ParquetReadOptions.builder().build()
 
   abstract private class StatsReader {

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/LazyDelegateStats.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/LazyDelegateStats.scala
@@ -17,7 +17,7 @@ private[parquet4s] class LazyDelegateStats(
     val fs = path.toHadoop.getFileSystem(hadoopConf)
     val statsArray = fs.listStatus(path.toHadoop).map {
       case status if filter.isInstanceOf[NoOpFilter] =>
-        new FileStats(status, vcc, hadoopConf, projectionSchemaOpt)
+        FileStats(status, vcc, hadoopConf, projectionSchemaOpt)
       case status =>
         new FilteredFileStats(status, vcc, hadoopConf, projectionSchemaOpt, filter)
     }

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/InMemoryOutputFileSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/InMemoryOutputFileSpec.scala
@@ -1,0 +1,28 @@
+package com.github.mjakubowski84.parquet4s
+
+import org.apache.commons.lang3.RandomStringUtils
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Files
+
+class InMemoryOutputFileSpec extends AnyFlatSpec with Matchers {
+  it should "write to in-memory output file" in {
+    case class Data(id: Int, text: String)
+
+    val count = 100
+    val data  = (1 to count).map(i => Data(id = i, text = RandomStringUtils.randomPrint(4)))
+    val file  = InMemoryOutputFile.create("test")
+
+    // write
+    ParquetWriter.of[Data].writeAndClose(file, data)
+
+    val inputFile = Files.createTempFile("in-memory-output-file-test", ".parquet")
+    Files.write(inputFile, file.toByteArray())
+
+    // read
+    val readData = ParquetReader.as[Data].read(Path(inputFile))
+    try readData.size shouldBe count
+    finally readData.close()
+  }
+}

--- a/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/rotatingWriter.scala
+++ b/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/rotatingWriter.scala
@@ -271,7 +271,11 @@ object rotatingWriter {
         for {
           internalWrite <- F.delay(
             scala.concurrent.blocking(
-              ParquetWriter.internalWriter(basePath.append(newFileName(options)), schema, options)
+              ParquetWriter.internalWriter(
+                basePath.append(newFileName(options)).toOutputFile(options),
+                schema,
+                options
+              )
             )
           )
           rotationFiber <- F.delayBy(eventQueue.offer(RotateEvent[F, T, W](basePath)), maxDuration).start

--- a/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/writer.scala
+++ b/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/writer.scala
@@ -145,7 +145,9 @@ private[parquet4s] object writer {
     val valueCodecConfiguration = ValueCodecConfiguration(options)
     in
       .evalMapChunk(entity => F.catchNonFatal(ParquetRecordEncoder.encode[T](entity, valueCodecConfiguration)))
-      .through(pipe(ParquetWriter.internalWriter(path, ParquetSchemaResolver.resolveSchema[T], options)))
+      .through(
+        pipe(ParquetWriter.internalWriter(path.toOutputFile(options), ParquetSchemaResolver.resolveSchema[T], options))
+      )
   }
 
   private def pipe[F[_]: Sync, T](makeParquetWriter: => HadoopParquetWriter[T]): Pipe[F, T, Nothing] =


### PR DESCRIPTION
We're trying to aggregate events using parquet before sending them to kinesis. It would be better to do the writes only in memory for this purpose to avoid actual IO operation.