### PR TITLE
add support for scalapb

### DIFF
--- a/akka/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetPartitioningFlow.scala
+++ b/akka/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetPartitioningFlow.scala
@@ -303,9 +303,10 @@ private class ParquetPartitioningFlow[T, W](
               logger.debug("Creating writer to write to [{}]", writerPath)
 
               val writer = ParquetWriter.internalWriter(
-                file    = Path(writerPath, newFileName).toOutputFile(writeOptions),
-                schema  = schema,
-                options = writeOptions
+                file          = Path(writerPath, newFileName).toOutputFile(writeOptions),
+                schema        = schema,
+                extraMetadata = ExtraMetadata.NoExtraMetadata,
+                options       = writeOptions
               )
 
               val state = WriterState(

--- a/akka/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetSource.scala
+++ b/akka/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetSource.scala
@@ -163,7 +163,13 @@ object ParquetSource extends IOOps {
       case _ =>
         val projectedSchemaOpt =
           projectedSchemaResolverOpt.map(implicit resolver => ParquetSchemaResolver.resolveSchema[T])
-        createSource(inputFile, projectedSchemaOpt, columnProjections, filter.toFilterCompat(valueCodecConfiguration), decoder)
+        createSource(
+          inputFile,
+          projectedSchemaOpt,
+          columnProjections,
+          filter.toFilterCompat(valueCodecConfiguration),
+          decoder
+        )
     }
 
     recordSource.map(decode)

--- a/akka/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetSource.scala
+++ b/akka/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetSource.scala
@@ -133,13 +133,13 @@ object ParquetSource extends IOOps {
 
   override protected val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  private def apply[T: ParquetRecordDecoder](
+  private def apply[T](
       inputFile: InputFile,
       options: ParquetReader.Options,
       filter: Filter,
       projectedSchemaResolverOpt: Option[ParquetSchemaResolver[T]],
       columnProjections: Seq[ColumnProjection]
-  ): Source[T, NotUsed] = {
+  )(implicit decoder: ParquetRecordDecoder[T]): Source[T, NotUsed] = {
     val valueCodecConfiguration = ValueCodecConfiguration(options)
     val hadoopConf              = options.hadoopConf
 
@@ -154,7 +154,7 @@ object ParquetSource extends IOOps {
               .map(implicit resolver => ParquetSchemaResolver.resolveSchema(partitionedDirectory.schema))
             val sources = PartitionFilter
               .filter(filter, valueCodecConfiguration, partitionedDirectory)
-              .map(createPartitionedSource(projectedSchemaOpt, columnProjections).tupled)
+              .map(createPartitionedSource(projectedSchemaOpt, columnProjections, decoder).tupled)
 
             if (sources.isEmpty) Source.empty
             else sources.reduceLeft(_.concat(_))
@@ -163,7 +163,7 @@ object ParquetSource extends IOOps {
       case _ =>
         val projectedSchemaOpt =
           projectedSchemaResolverOpt.map(implicit resolver => ParquetSchemaResolver.resolveSchema[T])
-        createSource(inputFile, projectedSchemaOpt, columnProjections, filter.toFilterCompat(valueCodecConfiguration))
+        createSource(inputFile, projectedSchemaOpt, columnProjections, filter.toFilterCompat(valueCodecConfiguration), decoder)
     }
 
     recordSource.map(decode)
@@ -171,9 +171,10 @@ object ParquetSource extends IOOps {
 
   private def createPartitionedSource(
       projectedSchemaOpt: Option[MessageType],
-      columnProjections: Seq[ColumnProjection]
+      columnProjections: Seq[ColumnProjection],
+      decoder: ParquetRecordDecoder[_]
   ): (FilterCompat.Filter, PartitionedPath) => Source[RowParquetRecord, NotUsed] = { (filterCompat, partitionedPath) =>
-    createSource(partitionedPath.inputFile, projectedSchemaOpt, columnProjections, filterCompat)
+    createSource(partitionedPath.inputFile, projectedSchemaOpt, columnProjections, filterCompat, decoder)
       .map(setPartitionValues(partitionedPath))
   }
 
@@ -181,11 +182,12 @@ object ParquetSource extends IOOps {
       inputFile: InputFile,
       projectedSchemaOpt: Option[MessageType],
       columnProjections: Seq[ColumnProjection],
-      filterCompat: FilterCompat.Filter
+      filterCompat: FilterCompat.Filter,
+      decoder: ParquetRecordDecoder[_]
   ) =
     Source
       .unfoldResource[RowParquetRecord, org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]](
-        create = () => createReader(filterCompat, inputFile, projectedSchemaOpt, columnProjections),
+        create = () => createReader(filterCompat, inputFile, projectedSchemaOpt, columnProjections, decoder),
         read   = reader => Option(reader.read()),
         close  = _.close()
       )
@@ -199,8 +201,8 @@ object ParquetSource extends IOOps {
       filterCompat: FilterCompat.Filter,
       inputFile: InputFile,
       projectedSchemaOpt: Option[MessageType],
-      columnProjections: Seq[ColumnProjection]
+      columnProjections: Seq[ColumnProjection],
+      decoder: ParquetRecordDecoder[_]
   ): org.apache.parquet.hadoop.ParquetReader[RowParquetRecord] =
-    HadoopParquetReader(inputFile, projectedSchemaOpt, columnProjections, filterCompat).build()
-
+    HadoopParquetReader(inputFile, projectedSchemaOpt, columnProjections, filterCompat, decoder.setMetadata).build()
 }

--- a/akka/src/main/scala/com/github/mjakubowski84/parquet4s/SingleFileParquetSink.scala
+++ b/akka/src/main/scala/com/github/mjakubowski84/parquet4s/SingleFileParquetSink.scala
@@ -108,13 +108,13 @@ object SingleFileParquetSink {
 
   private val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
-  private def rowParquetRecordSink[T: ParquetRecordEncoder: ParquetSchemaResolver](
+  private def rowParquetRecordSink[T: ParquetSchemaResolver](
       outputFile: OutputFile,
       options: ParquetWriter.Options
-  ): Sink[T, Future[Done]] = {
+  )(implicit encoder: ParquetRecordEncoder[T]): Sink[T, Future[Done]] = {
     val valueCodecConfiguration = ValueCodecConfiguration(options)
     val schema                  = ParquetSchemaResolver.resolveSchema[T]
-    val writer                  = ParquetWriter.internalWriter(outputFile, schema, options)
+    val writer                  = ParquetWriter.internalWriter(outputFile, schema, encoder, options)
 
     def encode(data: T): RowParquetRecord = ParquetRecordEncoder.encode[T](data, valueCodecConfiguration)
 

--- a/build.sbt
+++ b/build.sbt
@@ -131,6 +131,27 @@ lazy val fs2 = (project in file("fs2"))
   .settings(testReportSettings)
   .dependsOn(core % "compile->compile;test->test", testkit % "it->compile")
 
+lazy val scalapb = (project in file("scalapb"))
+  .configs(IntegrationTest)
+  .settings(
+    name := "parquet4s-scalapb",
+    crossScalaVersions := supportedScalaVersions,
+    libraryDependencies ++= Seq(
+      "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.13",
+      "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
+      "org.apache.hadoop" % "hadoop-client" % hadoopVersion % Test,
+      "org.apache.parquet" % "parquet-protobuf" % parquetVersion % Test
+    ),
+    Test / PB.targets := Seq(
+      _root_.scalapb.gen(flatPackage = true, lenses = false) -> ((Test / sourceManaged).value / "protobuf/scala"),
+      PB.gens.java -> ((Test / sourceManaged).value / "protobuf/java")
+    )
+  )
+  .settings(compilationSettings)
+  .settings(publishSettings)
+  .settings(testReportSettings)
+  .dependsOn(core % "compile->compile;test->test", akka % "test->test", testkit % "it->compile")
+
 lazy val testkit = (project in file("testkit"))
   .settings(
     name := "parquet4s-testkit",
@@ -173,11 +194,14 @@ lazy val examples = (project in file("examples"))
     evictionErrorLevel := util.Level.Warn,
     run / cancelable := true,
     run / fork := true,
-    compileOrder := CompileOrder.JavaThenScala
+    compileOrder := CompileOrder.JavaThenScala,
+    Compile / PB.targets := Seq(
+      _root_.scalapb.gen(flatPackage = true, lenses = false) -> ((Compile / sourceManaged).value / "protobuf/scala"),
+      PB.gens.java -> ((Test / sourceManaged).value / "protobuf/java")
+    )
   )
   .settings(compilationSettings)
-  .dependsOn(akka, fs2)
-  .enablePlugins(ProtobufPlugin)
+  .dependsOn(akka, fs2, scalapb)
 
 lazy val coreBenchmarks = (project in file("coreBenchmarks"))
   .settings(
@@ -275,6 +299,7 @@ lazy val root = (project in file("."))
     core,
     akka,
     fs2,
+    scalapb,
     testkit,
     examples,
     coreBenchmarks,

--- a/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
+++ b/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
@@ -25,6 +25,7 @@ trait ParquetRecordDecoder[T] {
     */
   def decode(record: RowParquetRecord, configuration: ValueCodecConfiguration): T
 
+  def setMetadata(metadata: collection.Map[String, String]): Unit = {}
 }
 
 object ParquetRecordDecoder {

--- a/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
+++ b/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
@@ -3,7 +3,7 @@ package com.github.mjakubowski84.parquet4s
 import shapeless.labelled.{FieldType, field}
 import shapeless.{::, HList, HNil, LabelledGeneric, Lazy, Witness}
 
-import scala.annotation.implicitNotFound
+import scala.annotation.{implicitNotFound, unused}
 import scala.util.control.NonFatal
 
 /** Type class that allows to decode instances of [[RowParquetRecord]]
@@ -25,7 +25,7 @@ trait ParquetRecordDecoder[T] {
     */
   def decode(record: RowParquetRecord, configuration: ValueCodecConfiguration): T
 
-  def setMetadata(metadata: collection.Map[String, String]): Unit = {}
+  def setMetadata(@unused metadata: collection.Map[String, String]): Unit = {}
 }
 
 object ParquetRecordDecoder {

--- a/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ParquetRecordEncoder.scala
+++ b/core/src/main/scala-2.12/com/github/mjakubowski84/parquet4s/ParquetRecordEncoder.scala
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
   "Cannot write data of type ${T}. " +
     "Please check if there is implicit ValueEncoder available for each field and subfield of ${T}."
 )
-trait ParquetRecordEncoder[T] {
+trait ParquetRecordEncoder[T] extends ExtraMetadata {
 
   /** @param entity
     *   data to be encoded
@@ -32,6 +32,7 @@ trait ParquetRecordEncoder[T] {
       configuration: ValueCodecConfiguration
   ): RowParquetRecord
 
+  override def getExtraMetadata(): Map[String, String] = Map.empty
 }
 
 sealed trait EmptyRowParquetRecordResolver {

--- a/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
+++ b/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
@@ -25,6 +25,7 @@ trait ParquetRecordDecoder[T] {
     */
   def decode(record: RowParquetRecord, configuration: ValueCodecConfiguration): T
 
+  def setMetadata(metadata: collection.Map[String, String]): Unit = {}
 }
 
 object ParquetRecordDecoder {

--- a/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
+++ b/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
@@ -3,7 +3,7 @@ package com.github.mjakubowski84.parquet4s
 import shapeless.labelled.{FieldType, field}
 import shapeless.{::, HList, HNil, LabelledGeneric, Lazy, Witness}
 
-import scala.annotation.implicitNotFound
+import scala.annotation.{implicitNotFound, unused}
 import scala.util.control.NonFatal
 
 /** Type class that allows to decode instances of [[RowParquetRecord]]
@@ -25,7 +25,7 @@ trait ParquetRecordDecoder[T] {
     */
   def decode(record: RowParquetRecord, configuration: ValueCodecConfiguration): T
 
-  def setMetadata(metadata: collection.Map[String, String]): Unit = {}
+  def setMetadata(@unused metadata: collection.Map[String, String]): Unit = {}
 }
 
 object ParquetRecordDecoder {

--- a/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ParquetRecordEncoder.scala
+++ b/core/src/main/scala-2.13/com/github/mjakubowski84/parquet4s/ParquetRecordEncoder.scala
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
   "Cannot write data of type ${T}. " +
     "Please check if there is implicit ValueEncoder available for each field and subfield of ${T}."
 )
-trait ParquetRecordEncoder[T] {
+trait ParquetRecordEncoder[T] extends ExtraMetadata {
 
   /** @param entity
     *   data to be encoded
@@ -32,6 +32,7 @@ trait ParquetRecordEncoder[T] {
       configuration: ValueCodecConfiguration
   ): RowParquetRecord
 
+  override def getExtraMetadata(): Map[String, String] = Map.empty
 }
 
 sealed trait EmptyRowParquetRecordResolver {

--- a/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
+++ b/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
@@ -23,6 +23,8 @@ trait ParquetRecordDecoder[T]:
     */
   def decode(record: RowParquetRecord, configuration: ValueCodecConfiguration): T
 
+  def setMetadata(metadata: collection.Map[String, String]): Unit = {}
+
 object ParquetRecordDecoder:
 
   object DecodingException:

--- a/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
+++ b/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ParquetRecordDecoder.scala
@@ -2,7 +2,7 @@ package com.github.mjakubowski84.parquet4s
 
 import scala.deriving.Mirror
 
-import scala.annotation.implicitNotFound
+import scala.annotation.{implicitNotFound, unused}
 import scala.util.control.NonFatal
 
 /** Type class that allows to decode instances of [[RowParquetRecord]]
@@ -23,7 +23,7 @@ trait ParquetRecordDecoder[T]:
     */
   def decode(record: RowParquetRecord, configuration: ValueCodecConfiguration): T
 
-  def setMetadata(metadata: collection.Map[String, String]): Unit = {}
+  def setMetadata(@unused metadata: collection.Map[String, String]): Unit = {}
 
 object ParquetRecordDecoder:
 

--- a/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ParquetRecordEncoder.scala
+++ b/core/src/main/scala-3/com/github/mjakubowski84/parquet4s/ParquetRecordEncoder.scala
@@ -13,7 +13,7 @@ import scala.reflect.ClassTag
   "Cannot write data of type ${T}. " +
     "Please check if there is implicit ValueEncoder available for each field and subfield of ${T}."
 )
-trait ParquetRecordEncoder[T]:
+trait ParquetRecordEncoder[T] extends ExtraMetadata:
   /** @param entity
     *   data to be encoded
     * @param resolver
@@ -28,6 +28,8 @@ trait ParquetRecordEncoder[T]:
       resolver: EmptyRowParquetRecordResolver,
       configuration: ValueCodecConfiguration
   ): RowParquetRecord
+
+  override def getExtraMetadata(): Map[String, String] = Map.empty
 
 object ParquetRecordEncoder:
 

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ExtraMetadata.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ExtraMetadata.scala
@@ -1,0 +1,9 @@
+package com.github.mjakubowski84.parquet4s
+
+private[parquet4s] object ExtraMetadata {
+  def NoExtraMetadata: ExtraMetadata = () => Map.empty
+}
+
+private[parquet4s] trait ExtraMetadata {
+  def getExtraMetadata(): Map[String, String]
+}

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/HadoopParquetReader.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/HadoopParquetReader.scala
@@ -10,11 +10,13 @@ object HadoopParquetReader {
   private class Builder(
       inputFile: InputFile,
       projectedSchemaOpt: Option[MessageType],
-      columnProjections: Seq[ColumnProjection]
+      columnProjections: Seq[ColumnProjection],
+      setMetadata: collection.Map[String, String] => Unit
   ) extends org.apache.parquet.hadoop.ParquetReader.Builder[RowParquetRecord](inputFile) {
     override lazy val getReadSupport: ReadSupport[RowParquetRecord] = new ParquetReadSupport(
       projectedSchemaOpt,
-      columnProjections
+      columnProjections,
+      setMetadata
     )
   }
 
@@ -22,8 +24,9 @@ object HadoopParquetReader {
       inputFile: InputFile,
       projectedSchemaOpt: Option[MessageType]  = None,
       columnProjections: Seq[ColumnProjection] = Seq.empty,
-      filter: FilterCompat.Filter              = FilterCompat.NOOP
+      filter: FilterCompat.Filter              = FilterCompat.NOOP,
+      setMetadata: collection.Map[String, String] => Unit = _ => ()
   ): org.apache.parquet.hadoop.ParquetReader.Builder[RowParquetRecord] =
-    new Builder(inputFile, projectedSchemaOpt, columnProjections).withFilter(filter)
+    new Builder(inputFile, projectedSchemaOpt, columnProjections, setMetadata).withFilter(filter)
 
 }

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReadSupport.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReadSupport.scala
@@ -16,8 +16,9 @@ import java.util
 import scala.jdk.CollectionConverters.*
 
 private[parquet4s] class ParquetReadSupport(
-    projectedSchemaOpt: Option[MessageType]  = None,
-    columnProjections: Seq[ColumnProjection] = Seq.empty
+    projectedSchemaOpt: Option[MessageType]             = None,
+    columnProjections: Seq[ColumnProjection]            = Seq.empty,
+    setMetadata: collection.Map[String, String] => Unit = _ => ()
 ) extends ReadSupport[RowParquetRecord] {
 
   override def prepareForRead(
@@ -25,12 +26,13 @@ private[parquet4s] class ParquetReadSupport(
       keyValueMetaData: util.Map[String, String],
       fileSchema: MessageType,
       readContext: ReadSupport.ReadContext
-  ): RecordMaterializer[RowParquetRecord] =
+  ): RecordMaterializer[RowParquetRecord] = {
+    setMetadata(keyValueMetaData.asScala)
     new ParquetRecordMaterializer(readContext.getRequestedSchema, columnProjections)
+  }
 
   override def init(context: InitContext): ReadSupport.ReadContext =
     new ReadSupport.ReadContext(projectedSchemaOpt.foldLeft(context.getFileSchema)(ReadSupport.getSchemaForRead))
-
 }
 
 private[parquet4s] class ParquetRecordMaterializer(

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReader.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReader.scala
@@ -134,7 +134,11 @@ object ParquetReader extends IOOps {
       }
       ParquetIterable[T](
         iteratorFactory = () =>
-          new ParquetIterator(HadoopParquetReader(inputFile, projectedSchemaOpt, columnProjections, filterCompat)),
+          new ParquetIterator(
+            HadoopParquetReader(inputFile, projectedSchemaOpt, columnProjections, setMetadata = decoder.setMetadata)
+              .withConf(hadoopConf)
+              .withFilter(filterCompat)
+          ),
         valueCodecConfiguration = valueCodecConfiguration,
         stats = Stats(inputFile, valueCodecConfiguration, hadoopConf, projectedSchemaOpt, filterCompat)
       )

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/scalapb/WriteAndReadApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/scalapb/WriteAndReadApp.scala
@@ -1,0 +1,21 @@
+package com.github.mjakubowski84.parquet4s.scalapb
+
+import com.github.mjakubowski84.parquet4s.ScalaPBImplicits.*
+import com.github.mjakubowski84.parquet4s.protobuf.Data
+import com.github.mjakubowski84.parquet4s.{ParquetReader, ParquetWriter, Path}
+
+import java.nio.file.Files
+
+object WriteAndReadApp extends App {
+  val data = (1 to 100).map(id => Data(id = id, text = id.toString))
+  val path = Path(Files.createTempDirectory("example"))
+
+  // write
+  ParquetWriter.of[Data].writeAndClose(path.append("data.parquet"), data)
+
+  // read
+  val readData = ParquetReader.as[Data].read(path)
+  // hint: you can filter by dict using string value, for example: filter = Col("dict") === "A"
+  try readData.foreach(println)
+  finally readData.close()
+}

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/scalapb/WriteIncrementallyAndReadApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/scalapb/WriteIncrementallyAndReadApp.scala
@@ -1,0 +1,23 @@
+package com.github.mjakubowski84.parquet4s.scalapb
+
+import com.github.mjakubowski84.parquet4s.ScalaPBImplicits.*
+import com.github.mjakubowski84.parquet4s.protobuf.Data
+import com.github.mjakubowski84.parquet4s.{ParquetReader, ParquetWriter, Path}
+
+import java.nio.file.Files
+
+object WriteIncrementallyAndReadApp extends App {
+  val count = 100
+  val data  = (1 to count).map(id => Data(id = id, text = id.toString))
+  val path  = Path(Files.createTempDirectory("example"))
+
+  // write
+  val writer = ParquetWriter.of[Data].build(path.append("data.parquet"))
+  try data.foreach(entity => writer.write(entity))
+  finally writer.close()
+
+  // read
+  val readData = ParquetReader.as[Data].read(path)
+  try readData.foreach(println)
+  finally readData.close()
+}

--- a/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/rotatingWriter.scala
+++ b/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/rotatingWriter.scala
@@ -272,6 +272,7 @@ object rotatingWriter {
               ParquetWriter.internalWriter(
                 basePath.append(newFileName(options)).toOutputFile(options),
                 schema,
+                ExtraMetadata.NoExtraMetadata,
                 options
               )
             )

--- a/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/writer.scala
+++ b/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/writer.scala
@@ -3,6 +3,7 @@ package com.github.mjakubowski84.parquet4s.parquet
 import cats.effect.{Resource, Sync}
 import cats.implicits.*
 import com.github.mjakubowski84.parquet4s.{
+  ExtraMetadata,
   ParquetRecordEncoder,
   ParquetSchemaResolver,
   ParquetWriter,
@@ -155,7 +156,15 @@ private[parquet4s] object writer {
     in
       .evalMapChunk(entity => F.catchNonFatal(ParquetRecordEncoder.encode[T](entity, valueCodecConfiguration)))
       .through(
-        pipe(ParquetWriter.internalWriter(outputFile, ParquetSchemaResolver.resolveSchema[T], options))
+        pipe(
+          ParquetWriter
+            .internalWriter(
+              outputFile,
+              ParquetSchemaResolver.resolveSchema[T],
+              ExtraMetadata.NoExtraMetadata,
+              options
+            )
+        )
       )
   }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,6 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.5")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "1.4.3")
-addSbtPlugin("com.github.sbt" % "sbt-protobuf" % "0.7.2")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.13"

--- a/scalapb/src/main/scala/com/github/mjakubowski84/parquet4s/ScalaPBImplicits.scala
+++ b/scalapb/src/main/scala/com/github/mjakubowski84/parquet4s/ScalaPBImplicits.scala
@@ -1,0 +1,102 @@
+package com.github.mjakubowski84.parquet4s
+
+import scalapb.descriptors.{Descriptor, FieldDescriptor, ScalaType}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+import org.apache.parquet.schema.LogicalTypeAnnotation.{enumType, listType, mapType, stringType}
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*
+import org.apache.parquet.schema.Types.{Builder, GroupBuilder}
+import org.apache.parquet.schema.{PrimitiveType, Type, Types}
+
+import scala.util.matching.Regex
+
+object ScalaPBImplicits {
+  implicit def scalapbParquetRecordEncoder[T <: GeneratedMessage]: ParquetRecordEncoder[T] =
+    new ScalaPBParquetRecordEncoder[T]
+
+  implicit def scalaPBParquetRecordDecoder[T <: GeneratedMessage: GeneratedMessageCompanion]: ParquetRecordDecoder[T] =
+    new ScalaPBParquetRecordDecoder[T]
+
+  implicit def scalapbParquetSchemaResolver[T <: GeneratedMessage: GeneratedMessageCompanion]
+      : ParquetSchemaResolver[T] =
+    new ScalaPBParquetSchemaResolver[T]
+
+  private[parquet4s] val MetadataEnumPrefix: String  = "parquet.proto.enum."
+  private[parquet4s] val EnumNameNumberPairRe: Regex = "(.*?):(.*?)(?:,|$)".r
+
+  implicit private[parquet4s] class RichGroupBuilder[T](private val builder: GroupBuilder[T]) extends AnyVal {
+    def addField(fd: FieldDescriptor): Builder[_ <: Builder[_, GroupBuilder[T]], GroupBuilder[T]] =
+      fd.scalaType match {
+        case ScalaType.Message(md) =>
+          if (fd.isMapField) addMapField(md.fields)
+          else if (fd.isRepeated) addRepeatedMessage(md)
+          else builder.group(repetition(fd)).addFields(md.fields)
+        case _ =>
+          val rawType = primitiveType(fd)
+          if (fd.isRepeated) addRepeatedPrimitive(rawType)
+          else builder.primitive(rawType.getPrimitiveTypeName, repetition(fd)).as(rawType.getLogicalTypeAnnotation)
+      }
+
+    def addMapField(fields: Vector[FieldDescriptor]): GroupBuilder[GroupBuilder[T]] = {
+      val keyFd   = fields.head
+      val valFd   = fields.tail.head
+      val keyType = primitiveType(keyFd).asPrimitiveType()
+      builder
+        .optionalGroup()
+        .as(mapType())
+        .addMapKey(keyType)
+        .addField(valFd)
+        .named("value")
+        .named("key_value")
+    }
+
+    def addMapKey(keyType: PrimitiveType): GroupBuilder[GroupBuilder[T]] =
+      builder
+        .repeatedGroup()
+        .primitive(keyType.getPrimitiveTypeName, Type.Repetition.REQUIRED)
+        .as(keyType.getLogicalTypeAnnotation)
+        .named("key")
+
+    def addRepeatedMessage(fd: Descriptor): GroupBuilder[GroupBuilder[T]] =
+      builder
+        .optionalGroup()
+        .as(listType())
+        .repeatedGroup()
+        .optionalGroup()
+        .addFields(fd.fields)
+        .named("element")
+        .named("list")
+
+    def addRepeatedPrimitive(elementType: PrimitiveType) =
+      builder
+        .optionalGroup()
+        .as(listType())
+        .repeatedGroup()
+        .primitive(elementType.getPrimitiveTypeName, Type.Repetition.REQUIRED)
+        .as(elementType.getLogicalTypeAnnotation)
+        .named("element")
+        .named("list")
+
+    def addFields(fields: Vector[FieldDescriptor]): GroupBuilder[T] =
+      fields.foldLeft(builder)((builder, fd) => builder.addField(fd).id(fd.index).named(fd.name))
+
+    def primitiveType(fd: FieldDescriptor): PrimitiveType = {
+      val rep = repetition(fd)
+      fd.scalaType match {
+        case ScalaType.Boolean    => Types.primitive(BOOLEAN, rep).named(fd.name)
+        case ScalaType.Enum(_)    => Types.primitive(BINARY, rep).as(enumType()).named(fd.name)
+        case ScalaType.Int        => Types.primitive(INT32, rep).named(fd.name)
+        case ScalaType.Long       => Types.primitive(INT64, rep).named(fd.name)
+        case ScalaType.Float      => Types.primitive(FLOAT, rep).named(fd.name)
+        case ScalaType.Double     => Types.primitive(DOUBLE, rep).named(fd.name)
+        case ScalaType.String     => Types.primitive(BINARY, rep).as(stringType()).named(fd.name)
+        case ScalaType.ByteString => Types.primitive(BINARY, rep).named(fd.name)
+        case ScalaType.Message(_) => throw new IllegalArgumentException(s"Field is not primitive type: ${fd.fullName}")
+      }
+    }
+
+    def repetition(fd: FieldDescriptor): Type.Repetition =
+      if (fd.isRequired) Type.Repetition.REQUIRED
+      else if (fd.isRepeated) Type.Repetition.REPEATED
+      else Type.Repetition.OPTIONAL;
+  }
+}

--- a/scalapb/src/main/scala/com/github/mjakubowski84/parquet4s/ScalaPBParquetRecordDecoder.scala
+++ b/scalapb/src/main/scala/com/github/mjakubowski84/parquet4s/ScalaPBParquetRecordDecoder.scala
@@ -1,0 +1,69 @@
+package com.github.mjakubowski84.parquet4s
+
+import com.github.mjakubowski84.parquet4s.ScalaPBImplicits.*
+import com.google.protobuf.ByteString
+import org.apache.parquet.io.api.Binary
+import scalapb.descriptors.*
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+
+import scala.util.control.NoStackTrace
+
+case class ScalaPBParquetDecodeException(msg: String) extends RuntimeException(msg) with NoStackTrace
+
+class ScalaPBParquetRecordDecoder[T <: GeneratedMessage: GeneratedMessageCompanion] extends ParquetRecordDecoder[T] {
+  private val cmp                                                    = implicitly[GeneratedMessageCompanion[T]]
+  private var enumMetadata: collection.Map[String, Map[String, Int]] = Map.empty
+
+  override def setMetadata(metadata: collection.Map[String, String]): Unit =
+    enumMetadata = metadata.collect {
+      case (key, value) if key.startsWith(MetadataEnumPrefix) =>
+        val enumName   = key.substring(MetadataEnumPrefix.length)
+        val enumValues = EnumNameNumberPairRe.findAllMatchIn(value).map(m => (m.group(1), m.group(2).toInt)).toMap
+        (enumName, enumValues)
+    }
+
+  override def decode(record: RowParquetRecord, configuration: ValueCodecConfiguration): T =
+    cmp.messageReads.read(decodeMessage(record, cmp.scalaDescriptor.fields))
+
+  private def decodeMessage(row: RowParquetRecord, fields: Vector[FieldDescriptor]): PMessage =
+    PMessage(fields.flatMap(fd => row.get(fd.name).map(v => fd -> decodeField(fd, v))).toMap)
+
+  private def decodeField(fd: FieldDescriptor, value: Value): PValue =
+    (fd.scalaType, value) match {
+      case (ScalaType.Boolean, BooleanValue(value))       => PBoolean(value)
+      case (ScalaType.Long, LongValue(value))             => PLong(value)
+      case (ScalaType.Float, FloatValue(value))           => PFloat(value)
+      case (ScalaType.Double, DoubleValue(value))         => PDouble(value)
+      case (ScalaType.Int, IntValue(value))               => PInt(value)
+      case (ScalaType.Enum(ed), BinaryValue(value))       => decodeEnum(ed, value)
+      case (ScalaType.String, BinaryValue(value))         => PString(value.toStringUsingUTF8)
+      case (ScalaType.ByteString, BinaryValue(value))     => PByteString(ByteString.copyFrom(value.toByteBuffer))
+      case (_, list: ListParquetRecord)                   => PRepeated(list.iterator.map(decodeField(fd, _)).toVector)
+      case (ScalaType.Message(md), row: RowParquetRecord) => decodeMessage(row, md.fields)
+      case (ScalaType.Message(md), map: MapParquetRecord) if md.fields.size == 2 => decodeMap(md, map)
+      case (_, NullValue) => if (fd.isRepeated) PRepeated(Vector.empty) else PEmpty
+      case _ =>
+        throw ScalaPBParquetDecodeException(s"Unsupported combination of field and value: ${fd.scalaType}, ${value}")
+    }
+
+  private def decodeEnum(ed: EnumDescriptor, value: Binary): PEnum = {
+    val name = value.toStringUsingUTF8
+    enumMetadata
+      .get(ed.fullName)
+      .flatMap(_.get(name))
+      .map(ed.findValueByNumberCreatingIfUnknown(_))
+      .orElse(ed.values.find(_.name == name))
+      .map(PEnum(_))
+      .getOrElse(throw ScalaPBParquetDecodeException(s"Unrecognized value (${name}) for Enum:${ed.fullName}"))
+  }
+
+  private def decodeMap(md: Descriptor, record: MapParquetRecord) = {
+    val keyField   = md.fields(0)
+    val valueField = md.fields(1)
+    PRepeated(
+      record.iterator.map { case (key, value) =>
+        PMessage(Map(keyField -> decodeField(keyField, key), valueField -> decodeField(valueField, value)))
+      }.toVector
+    )
+  }
+}

--- a/scalapb/src/main/scala/com/github/mjakubowski84/parquet4s/ScalaPBParquetRecordEncoder.scala
+++ b/scalapb/src/main/scala/com/github/mjakubowski84/parquet4s/ScalaPBParquetRecordEncoder.scala
@@ -1,0 +1,72 @@
+package com.github.mjakubowski84.parquet4s
+
+import org.apache.parquet.io.api.Binary
+import scalapb.GeneratedMessage
+import scalapb.descriptors.*
+import com.github.mjakubowski84.parquet4s.ScalaPBImplicits.*
+
+import scala.collection.mutable
+import scala.util.control.NoStackTrace
+
+case class ScalaPBParquetEncodeException(msg: String) extends RuntimeException(msg) with NoStackTrace
+
+class ScalaPBParquetRecordEncoder[T <: GeneratedMessage] extends ParquetRecordEncoder[T] {
+  private val enumMetadata: mutable.Map[String, mutable.Map[String, Int]] = mutable.Map.empty
+
+  override def encode(
+      entity: T,
+      resolver: EmptyRowParquetRecordResolver,
+      configuration: ValueCodecConfiguration
+  ): RowParquetRecord =
+    encodeMessage(entity.toPMessage)
+
+  override def getExtraMetadata(): Map[String, String] =
+    enumMetadata.iterator.map { case (key, value) =>
+      val metadataEnumKey    = MetadataEnumPrefix + key
+      val metadataEnumValues = value.map { case (name, number) => s"$name:$number" }.mkString(",")
+      (metadataEnumKey, metadataEnumValues)
+    }.toMap
+
+  private def encodeMessage(msg: PMessage): RowParquetRecord =
+    RowParquetRecord(msg.value.view.map { case (fd, v) => fd.name -> encodeField(fd, v) }.toSeq)
+
+  private def encodeField(fd: FieldDescriptor, value: PValue): Value =
+    (fd.scalaType, value) match {
+      case (ScalaType.Boolean, PBoolean(value)) => BooleanValue(value)
+      case (ScalaType.Int, PInt(value))         => IntValue(value)
+      case (ScalaType.Long, PLong(value))       => LongValue(value)
+      case (ScalaType.Float, PFloat(value))     => FloatValue(value)
+      case (ScalaType.Double, PDouble(value))   => DoubleValue(value)
+      case (ScalaType.String, PString(value))   => BinaryValue(Binary.fromString(value))
+      case (ScalaType.ByteString, PByteString(value)) =>
+        BinaryValue(Binary.fromReusedByteBuffer(value.asReadOnlyByteBuffer()))
+      case (ScalaType.Message(_), msg: PMessage)                                              => encodeMessage(msg)
+      case (ScalaType.Message(md), PRepeated(values)) if fd.isMapField && md.fields.size == 2 => encodeMap(md, values)
+      case (_, PRepeated(values))            => ListParquetRecord(values.map(encodeField(fd, _)): _*)
+      case (_, PEmpty)                       => NullValue
+      case (ScalaType.Enum(_), PEnum(value)) => encodeEnumValue(value)
+      case _ =>
+        throw ScalaPBParquetEncodeException(s"Unsupported combination of field and value: ${fd.scalaType}, $value")
+    }
+
+  private def encodeMap(md: Descriptor, values: Vector[PValue]) = {
+    val entries = values.map {
+      case msg: PMessage if msg.value.size == 2 => encodeMapEntry(md.fields(0), md.fields(1), msg)
+      case value                                => throw ScalaPBParquetEncodeException(s"Invalid map entry: $value")
+    }
+    MapParquetRecord(entries: _*)
+  }
+
+  private def encodeMapEntry(keyFd: FieldDescriptor, valueFd: FieldDescriptor, msg: PMessage) =
+    (msg.value.get(keyFd), msg.value.get(valueFd)) match {
+      case (Some(key), Some(value)) => (encodeField(keyFd, key), encodeField(valueFd, value))
+      case _ =>
+        throw ScalaPBParquetEncodeException(s"Invaid map entry: key field: $keyFd, value field: $valueFd, msg: $msg")
+    }
+
+  private def encodeEnumValue(value: EnumValueDescriptor) = {
+    val enumName = value.containingEnum.fullName
+    enumMetadata.getOrElseUpdate(enumName, mutable.Map.empty).put(value.name, value.number)
+    BinaryValue(Binary.fromString(value.name))
+  }
+}

--- a/scalapb/src/main/scala/com/github/mjakubowski84/parquet4s/ScalaPBParquetSchemaResolver.scala
+++ b/scalapb/src/main/scala/com/github/mjakubowski84/parquet4s/ScalaPBParquetSchemaResolver.scala
@@ -1,0 +1,25 @@
+package com.github.mjakubowski84.parquet4s
+
+import com.github.mjakubowski84.parquet4s.ScalaPBImplicits._
+import org.apache.parquet.schema.{Type, Types}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+
+import scala.jdk.CollectionConverters.*
+
+class ScalaPBParquetSchemaResolver[T <: GeneratedMessage: GeneratedMessageCompanion] extends ParquetSchemaResolver[T] {
+  private val cmp = implicitly[GeneratedMessageCompanion[T]]
+
+  override def schemaName: Option[String] = Option(cmp.scalaDescriptor.name)
+
+  override def resolveSchema(cursor: Cursor): List[Type] = {
+    val md = cmp.scalaDescriptor
+    Types
+      .buildMessage()
+      .addFields(md.fields)
+      .named(md.fullName)
+      .getFields
+      .iterator()
+      .asScala
+      .toList
+  }
+}

--- a/scalapb/src/test/protobuf/data.proto
+++ b/scalapb/src/test/protobuf/data.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+option java_package = "com.github.mjakubowski84.parquet4s";
+
+message Data {
+  enum ABC {
+    A = 0;
+    B = 1;
+    C = 2;
+  }
+
+  message Inner {
+    string text = 1;
+  }
+
+  // primitive types
+  bool bool = 1;
+  int32 int = 2;
+  int64 long = 3;
+  float float = 4;
+  double double = 5;
+  string text = 6;
+  ABC abc = 7;
+
+  // message type
+  Inner inner = 8;
+
+  // map types
+  map<string, int32> map = 9;
+  map<int32, ABC> enum_map = 10;
+  map<int64, Inner> msg_map = 11;
+
+  // list types
+  repeated bool bool_list = 101;
+  repeated int32 int_list = 102;
+  repeated int64 long_list = 103;
+  repeated float float_list = 104;
+  repeated double double_list = 105;
+  repeated string text_list = 106;
+  repeated ABC enum_list = 107;
+  repeated Inner msg_list = 108;
+}

--- a/scalapb/src/test/scala/com/github/mjakubowski84/parquet4s/Parquet4sScalaPBSpec.scala
+++ b/scalapb/src/test/scala/com/github/mjakubowski84/parquet4s/Parquet4sScalaPBSpec.scala
@@ -1,0 +1,107 @@
+package com.github.mjakubowski84.parquet4s
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{Sink, Source}
+import akka.testkit.TestKit
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import com.github.mjakubowski84.parquet4s.DataOuterClass.Data as JData
+import com.github.mjakubowski84.parquet4s.ScalaPBImplicits.*
+import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.proto.{ProtoParquetWriter, ProtoWriteSupport}
+
+import java.nio.file.Files
+import scala.jdk.CollectionConverters.*
+
+class Parquet4sScalaPBSpec
+    extends TestKit(ActorSystem("parquet4s-scalapb"))
+    with AnyFlatSpecLike
+    with Matchers
+    with ScalaFutures {
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(3, Seconds), interval = Span(50, Millis))
+
+  def testWithData(newData: Int => Data): Unit = {
+    val data   = (1 to 100).map(newData)
+    val tmpDir = Path(Files.createTempDirectory("example"))
+    val file   = tmpDir.append("data.parquet")
+    val sink   = ParquetStreams.toParquetSingleFile.of[Data].write(file)
+    Source(data).runWith(sink).futureValue
+    ParquetStreams.fromParquet.as[Data].read(file).runWith(Sink.seq).futureValue shouldBe data
+  }
+
+  "parquet4s-scalapb" should "work with primitive types" in {
+    testWithData(i => Data(bool = i % 2 == 0))
+    testWithData(i => Data(int = i))
+    testWithData(i => Data(long = i.toLong))
+    testWithData(i => Data(float = i.toFloat))
+    testWithData(i => Data(double = i.toDouble))
+    testWithData(i => Data(text = i.toString))
+    testWithData(i => Data(abc = Data.ABC.fromValue(i % 3)))
+  }
+
+  it should "work with message types" in {
+    testWithData(i => Data(inner = Some(Data.Inner(i.toString))))
+  }
+
+  it should "work with unrecognized enum values" in {
+    testWithData(i => Data(abc = Data.ABC.fromValue(i % 5)))
+  }
+
+  it should "work with map types" in {
+    testWithData(i => Data(map = Map("original" -> i, "doubled" -> 2 * i)))
+    testWithData(i => Data(enumMap = Map(i -> Data.ABC.fromValue(i % 5))))
+    testWithData(i => Data(msgMap = Map(i.toLong -> Data.Inner(text = "level1"))))
+  }
+
+  it should "work with list types" in {
+    testWithData(i => Data(boolList = (i to i + 100).map(_ % 2 == 0)))
+    testWithData(i => Data(intList = i to i + 100))
+    testWithData(i => Data(longList = (i to i + 100).map(_.toLong)))
+    testWithData(i => Data(floatList = (i to i + 100).map(_.toFloat)))
+    testWithData(i => Data(doubleList = (i to i + 100).map(_.toDouble)))
+    testWithData(i => Data(textList = (i to i + 100).map(_.toString)))
+    testWithData(i => Data(enumList = (i to i + 100).map(Data.ABC.fromValue)))
+    testWithData(i => Data(msgList = (i to i + 100).map(i => Data.Inner(i.toString))))
+  }
+
+  it should "be compatible with parquet-protobuf" in {
+    val javaData = (1 to 100).map(i =>
+      JData
+        .newBuilder()
+        .setBool(i % 2 == 0)
+        .setInt(i)
+        .setLong(i.toLong)
+        .setFloat(i.toFloat)
+        .setDouble(i.toDouble)
+        .setText(i.toString)
+        .setAbcValue(i % JData.ABC.values().length)
+        .setInner(JData.Inner.newBuilder().setText(i.toString))
+        .addAllBoolList((i to i + 100).map(_ % 2 == 0).map(java.lang.Boolean.valueOf).asJava)
+        .addAllIntList((i to i + 100).map(Integer.valueOf).asJava)
+        .addAllLongList((i to i + 100).map(_.toLong).map(java.lang.Long.valueOf).asJava)
+        .addAllFloatList((i to i + 100).map(_.toFloat).map(java.lang.Float.valueOf).asJava)
+        .addAllDoubleList((i to i + 100).map(_.toDouble).map(java.lang.Double.valueOf).asJava)
+        .addAllTextList((i to i + 100).map(_.toString).asJava)
+        .addAllEnumListValue((i to i + 100).map(_ % JData.ABC.values().length).map(Integer.valueOf).asJava)
+        .addAllMsgList((i to i + 100).map(i => JData.Inner.newBuilder().setText(i.toString).build()).asJava)
+        .build()
+    )
+    val scalaData = javaData.map(d => Data.parseFrom(d.toByteArray))
+
+    val tmpDir = Path(Files.createTempDirectory("example"))
+    val file   = tmpDir.append("data.parquet")
+
+    val builder    = ProtoParquetWriter.builder[JData](file.hadoopPath).withMessage(classOf[JData])
+    val hadoopConf = new Configuration()
+    hadoopConf.setBoolean(ProtoWriteSupport.PB_SPECS_COMPLIANT_WRITE, true)
+    val sink = ParquetStreams.toParquetSingleFile
+      .custom[JData, ProtoParquetWriter.Builder[JData]](builder)
+      .options(ParquetWriter.Options(hadoopConf = hadoopConf))
+      .write
+    Source(javaData).runWith(sink).futureValue
+
+    ParquetStreams.fromParquet.as[Data].read(file).runWith(Sink.seq).futureValue shouldBe scalaData
+  }
+}


### PR DESCRIPTION
This PR adds a module (parquet4s-scalapb) to support read/write `GeneratedMessage`s by scalapb. It's compatible with parquet-protobuf - files written with parquet-protobuf configured with `parquet.proto.writeSpecCompaliant = true` can be read with parquet4s-scalapb, and files written with parquet4s-scalapb should also be readable by parquet-protobuf as long as there's no scala only features involved. 
