### PR TITLE
Deeper integration of Parquet InputFile and OutputFile. Applying to reading partitions, stats and FS2 module.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ lazy val three                  = "3.2.2"
 lazy val supportedScalaVersions = Seq(twoTwelve, twoThirteen, three)
 
 ThisBuild / organization := "com.github.mjakubowski84"
-ThisBuild / version := "2.11.1"
-ThisBuild / isSnapshot := false
+ThisBuild / version := "2.12.0-SNAPSHOT"
+ThisBuild / isSnapshot := true
 ThisBuild / scalaVersion := twoThirteen
 
 ThisBuild / javacOptions ++= Seq("-source", "1.8", "-target", "1.8")

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/IOOpsITSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/IOOpsITSpec.scala
@@ -131,30 +131,39 @@ class IOOpsITSpec extends AnyFlatSpec with Matchers with IOOps with TestUtils wi
   }
 
   it should "create single element partition in a path" in {
-    val pathX1 = tempPath.append("x=1")
-    fileSystem.createNewFile(pathX1.append("file.parquet").toHadoop)
+    val pathX1 = tempPath.append("x=1").append("file.parquet")
+    fileSystem.createNewFile(pathX1.toHadoop)
 
     val dir = findPartitionedPaths(tempPath, configuration).value
-    dir.paths should be(List(PartitionedPath(pathX1, (Col("x") -> "1") :: Nil)))
+    dir.paths should be(List(PartitionedPath(pathX1, configuration, (Col("x") -> "1") :: Nil)))
     dir.schema should be(Col("x") :: Nil)
   }
 
+  it should "return a partitioned directory with single file of no partitions values" in {
+    val pathX1 = tempPath.append("x=1").append("file.parquet")
+    fileSystem.createNewFile(pathX1.toHadoop)
+
+    val dir = findPartitionedPaths(pathX1, configuration).value
+    dir.paths should be(List(PartitionedPath(pathX1, configuration, Nil)))
+    dir.schema should be(empty)
+  }
+
   it should "create proper partitions for complex tree" in {
-    val path1 = tempPath.append("x=1/y=a/z=1_1")
-    val path2 = tempPath.append("x=1/y=b/z=1_2")
-    val path3 = tempPath.append("x=1/y=c/z=1_3")
-    val path4 = tempPath.append("x=2/y=b/z=0_9")
-    fileSystem.createNewFile(path1.append("file.parquet").toHadoop)
-    fileSystem.createNewFile(path2.append("file.parquet").toHadoop)
-    fileSystem.createNewFile(path3.append("file.parquet").toHadoop)
-    fileSystem.createNewFile(path4.append("file.parquet").toHadoop)
+    val path1 = tempPath.append("x=1/y=a/z=1_1").append("file.parquet")
+    val path2 = tempPath.append("x=1/y=b/z=1_2").append("file.parquet")
+    val path3 = tempPath.append("x=1/y=c/z=1_3").append("file.parquet")
+    val path4 = tempPath.append("x=2/y=b/z=0_9").append("file.parquet")
+    fileSystem.createNewFile(path1.toHadoop)
+    fileSystem.createNewFile(path2.toHadoop)
+    fileSystem.createNewFile(path3.toHadoop)
+    fileSystem.createNewFile(path4.toHadoop)
 
     val dir = findPartitionedPaths(tempPath, configuration).value
     dir.paths should contain theSameElementsAs List(
-      PartitionedPath(path1, List(Col("x") -> "1", Col("y") -> "a", Col("z") -> "1_1")),
-      PartitionedPath(path2, List(Col("x") -> "1", Col("y") -> "b", Col("z") -> "1_2")),
-      PartitionedPath(path3, List(Col("x") -> "1", Col("y") -> "c", Col("z") -> "1_3")),
-      PartitionedPath(path4, List(Col("x") -> "2", Col("y") -> "b", Col("z") -> "0_9"))
+      PartitionedPath(path1, configuration, List(Col("x") -> "1", Col("y") -> "a", Col("z") -> "1_1")),
+      PartitionedPath(path2, configuration, List(Col("x") -> "1", Col("y") -> "b", Col("z") -> "1_2")),
+      PartitionedPath(path3, configuration, List(Col("x") -> "1", Col("y") -> "c", Col("z") -> "1_3")),
+      PartitionedPath(path4, configuration, List(Col("x") -> "2", Col("y") -> "b", Col("z") -> "0_9"))
     )
     dir.schema should be(List(Col("x"), Col("y"), Col("z")))
   }

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetDfsItSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetDfsItSpec.scala
@@ -25,7 +25,7 @@ class ParquetDfsItSpec extends AnyFlatSpec with ForAllMiniDfsCluster {
     ParquetWriter.of[Data].options(writeOptions).writeAndClose(inPath, makeTestData())
     // When
     val outWriter  = ParquetWriter.of[Data].options(writeOptions).build(outPath)
-    val inIterable = ParquetReader.as[Data].options(readOptions).partitioned.read(inPath)
+    val inIterable = ParquetReader.as[Data].options(readOptions).read(inPath)
 
     try outWriter.write(inIterable.map(d => d.copy(i = d.i + 1)))
     finally {

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetReaderItSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetReaderItSpec.scala
@@ -45,7 +45,7 @@ class ParquetReaderItSpec extends AnyFreeSpec with Matchers with TestUtils with 
     ParquetWriter.of[I].writeAndClose(Path(tempPath, "a=a2/b=b1/file.parquet"), Seq(I(3)))
     ParquetWriter.of[I].writeAndClose(Path(tempPath, "a=a2/b=b2/file.parquet"), Seq(I(4)))
 
-    val partitioned = ParquetReader.as[Partitioned].partitioned.read(tempPath)
+    val partitioned = ParquetReader.as[Partitioned].read(tempPath)
     try partitioned.toSeq should contain theSameElementsAs
       Seq(
         Partitioned(a = "a1", b = "b1", i = 1),
@@ -62,7 +62,7 @@ class ParquetReaderItSpec extends AnyFreeSpec with Matchers with TestUtils with 
     ParquetWriter.of[I].writeAndClose(Path(tempPath, "a=a2/b=b1/file.parquet"), Seq(I(3)))
     ParquetWriter.of[I].writeAndClose(Path(tempPath, "a=a2/b=b2/file.parquet"), Seq(I(4)))
 
-    val partitioned = ParquetReader.as[Partitioned].partitioned.filter(Col("b") === "b1").read(tempPath)
+    val partitioned = ParquetReader.as[Partitioned].filter(Col("b") === "b1").read(tempPath)
     try partitioned.toSeq should contain theSameElementsAs
       Seq(
         Partitioned(a = "a1", b = "b1", i = 1),
@@ -74,7 +74,7 @@ class ParquetReaderItSpec extends AnyFreeSpec with Matchers with TestUtils with 
   "Attempt to read partitions on non-partitioned data should succeed" in {
     ParquetWriter.of[I].writeAndClose(Path(tempPath, "file.parquet"), Seq(I(1), I(2)))
 
-    val data = ParquetReader.as[I].partitioned.read(tempPath)
+    val data = ParquetReader.as[I].read(tempPath)
     try data.toSeq should be(Seq(I(1), I(2)))
     finally data.close()
   }
@@ -83,7 +83,7 @@ class ParquetReaderItSpec extends AnyFreeSpec with Matchers with TestUtils with 
     ParquetWriter.of[I].writeAndClose(Path(tempPath, "a=a1/b=b1/file.parquet"), Seq(I(1)))
     ParquetWriter.of[I].writeAndClose(Path(tempPath, "a=a2/file.parquet"), Seq(I(2)))
 
-    an[IllegalArgumentException] should be thrownBy ParquetReader.as[Partitioned].partitioned.read(tempPath)
+    an[IllegalArgumentException] should be thrownBy ParquetReader.as[Partitioned].read(tempPath)
   }
 
 }

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/HadoopParquetReader.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/HadoopParquetReader.scala
@@ -1,0 +1,29 @@
+package com.github.mjakubowski84.parquet4s
+
+import org.apache.parquet.filter2.compat.FilterCompat
+import org.apache.parquet.hadoop.api.ReadSupport
+import org.apache.parquet.io.InputFile
+import org.apache.parquet.schema.MessageType
+
+object HadoopParquetReader {
+
+  private class Builder(
+      inputFile: InputFile,
+      projectedSchemaOpt: Option[MessageType],
+      columnProjections: Seq[ColumnProjection]
+  ) extends org.apache.parquet.hadoop.ParquetReader.Builder[RowParquetRecord](inputFile) {
+    override lazy val getReadSupport: ReadSupport[RowParquetRecord] = new ParquetReadSupport(
+      projectedSchemaOpt,
+      columnProjections
+    )
+  }
+
+  def apply(
+      inputFile: InputFile,
+      projectedSchemaOpt: Option[MessageType]  = None,
+      columnProjections: Seq[ColumnProjection] = Seq.empty,
+      filter: FilterCompat.Filter              = FilterCompat.NOOP
+  ): org.apache.parquet.hadoop.ParquetReader.Builder[RowParquetRecord] =
+    new Builder(inputFile, projectedSchemaOpt, columnProjections).withFilter(filter)
+
+}

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
@@ -3,6 +3,7 @@ package com.github.mjakubowski84.parquet4s
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FileStatus, FileSystem, RemoteIterator}
 import org.apache.parquet.hadoop.ParquetFileWriter
+import org.apache.parquet.hadoop.util.HiddenFileFilter
 import org.slf4j.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -72,7 +73,7 @@ trait IOOps {
       configuration: Configuration
   ): Either[Exception, PartitionedDirectory] = {
     val fs = path.toHadoop.getFileSystem(configuration)
-    findPartitionedPaths(fs, path, List.empty).fold(
+    findPartitionedPaths(fs, configuration, path, List.empty).fold(
       PartitionedDirectory.failed,
       PartitionedDirectory.apply
     )
@@ -80,10 +81,14 @@ trait IOOps {
 
   private def findPartitionedPaths(
       fs: FileSystem,
+      configuration: Configuration,
       path: Path,
       partitions: List[Partition]
   ): Either[List[Path], List[PartitionedPath]] = {
-    val (dirs, files) = fs.listStatus(path.toHadoop).toList.partition(_.isDirectory)
+    val (dirs, files) = fs
+      .listStatus(path.toHadoop, HiddenFileFilter.INSTANCE)
+      .toList
+      .partition(_.isDirectory)
     if (dirs.nonEmpty && files.nonEmpty)
       Left(path :: Nil) // path is invalid because it contains both dirs and files
     else {
@@ -91,10 +96,13 @@ trait IOOps {
       if (partitionedDirs.isEmpty && files.isEmpty)
         Right(List.empty) // empty leaf dir
       else if (partitionedDirs.isEmpty)
-        Right(List(PartitionedPath(path, partitions))) // leaf dir with files
+        // leaf files
+        Right(files.map(fileStatus => PartitionedPath(fileStatus, configuration, partitions)))
       else
         partitionedDirs
-          .map { case (subPath, partition) => findPartitionedPaths(fs, subPath, partitions :+ partition) }
+          .map { case (subPath, partition) =>
+            findPartitionedPaths(fs, configuration, subPath, partitions :+ partition)
+          }
           .foldLeft[Either[List[Path], List[PartitionedPath]]](Right(List.empty)) {
             case (Left(invalidPaths), Left(moreInvalidPaths)) =>
               Left(invalidPaths ++ moreInvalidPaths)

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/InMemoryOutputFile.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/InMemoryOutputFile.scala
@@ -8,10 +8,10 @@ import scala.language.reflectiveCalls
 import scala.util.control.NoStackTrace
 
 object InMemoryOutputFile {
-  def create(name: String): InMemoryOutputFile = new InMemoryOutputFile(name)
+  def apply(name: String): InMemoryOutputFile = new InMemoryOutputFile(name)
 }
 
-class InMemoryOutputFile(name: String) extends OutputFile {
+class InMemoryOutputFile private (name: String) extends OutputFile {
   private val os = new ByteArrayOutputStream()
 
   override def create(blockSizeHint: Long): PositionOutputStream = {
@@ -33,5 +33,5 @@ class InMemoryOutputFile(name: String) extends OutputFile {
   override def defaultBlockSize(): Long =
     throw new UnsupportedOperationException("Block size is not supported by InMemoryOutputFile") with NoStackTrace
 
-  def toByteArray(): Array[Byte] = os.toByteArray
+  def toByteArray: Array[Byte] = os.toByteArray
 }

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetIterator.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetIterator.scala
@@ -1,10 +1,9 @@
 package com.github.mjakubowski84.parquet4s
 
 import java.io.Closeable
-import org.apache.parquet.hadoop.ParquetReader as HadoopParquetReader
 
 private[parquet4s] object ParquetIterator {
-  private[parquet4s] type HadoopBuilder = HadoopParquetReader.Builder[RowParquetRecord]
+  private[parquet4s] type HadoopBuilder = org.apache.parquet.hadoop.ParquetReader.Builder[RowParquetRecord]
 
   def factory(builder: HadoopBuilder): () => Iterator[RowParquetRecord] & Closeable =
     () => new ParquetIterator(builder)

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/PartitionFilter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/PartitionFilter.scala
@@ -2,17 +2,35 @@ package com.github.mjakubowski84.parquet4s
 
 import com.github.mjakubowski84.parquet4s.FilterRewriter.{IsFalse, IsTrue}
 import com.github.mjakubowski84.parquet4s.PartitionedDirectory.PartitioningSchema
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileStatus
 import org.apache.parquet.filter2.compat.FilterCompat
 import org.apache.parquet.filter2.predicate.Operators.Column
 import org.apache.parquet.filter2.predicate.{FilterApi, FilterPredicate, Operators, UserDefinedPredicate}
+import org.apache.parquet.hadoop.util.HadoopInputFile
+import org.apache.parquet.io.InputFile
 import org.apache.parquet.io.api.Binary
 import org.apache.parquet.schema.PrimitiveComparator
 import org.slf4j.LoggerFactory
 
 object PartitionedPath {
 
-  def apply(path: Path, partitions: List[(ColumnPath, String)]): PartitionedPath =
-    new PartitionedPathImpl(path, partitions.map { case (name, value) => (name, Binary.fromString(value)) })
+  def apply(
+      fileStatus: FileStatus,
+      configuration: Configuration,
+      partitions: List[(ColumnPath, String)]
+  ): PartitionedPath =
+    apply(HadoopInputFile.fromStatus(fileStatus, configuration), partitions)
+
+  def apply(path: Path, configuration: Configuration, partitions: List[(ColumnPath, String)]): PartitionedPath =
+    apply(HadoopInputFile.fromPath(path.toHadoop, configuration), partitions)
+
+  def apply(hadoopInputFile: HadoopInputFile, partitions: List[(ColumnPath, String)]): PartitionedPath =
+    new PartitionedPathImpl(
+      path       = Path(hadoopInputFile.getPath),
+      inputFile  = hadoopInputFile,
+      partitions = partitions.map { case (name, value) => (name, Binary.fromString(value)) }
+    )
 
 }
 
@@ -25,6 +43,11 @@ trait PartitionedPath {
     *   file system path
     */
   def path: Path
+
+  /** @return
+    *   file for reading
+    */
+  def inputFile: InputFile
 
   /** @return
     *   list of partition names
@@ -45,6 +68,7 @@ trait PartitionedPath {
 
 private class PartitionedPathImpl(
     override val path: Path,
+    override val inputFile: InputFile,
     override val partitions: List[(ColumnPath, Binary)]
 ) extends PartitionedPath {
 

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/Path.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/Path.scala
@@ -1,10 +1,9 @@
 package com.github.mjakubowski84.parquet4s
 
-import com.github.mjakubowski84.parquet4s.ParquetWriter.Options
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path as HadoopPath
-import org.apache.parquet.hadoop.util.HadoopOutputFile
-import org.apache.parquet.io.OutputFile
+import org.apache.parquet.hadoop.util.{HadoopInputFile, HadoopOutputFile}
+import org.apache.parquet.io.{InputFile, OutputFile}
 
 import java.net.URI
 import java.nio.file.{Paths, Path as NioPath}
@@ -43,7 +42,11 @@ class Path private (val hadoopPath: HadoopPath) {
 
   def toOutputFile(conf: Configuration): OutputFile = HadoopOutputFile.fromPath(hadoopPath, conf)
 
-  def toOutputFile(options: Options): OutputFile = toOutputFile(options.hadoopConf)
+  def toOutputFile(options: ParquetWriter.Options): OutputFile = toOutputFile(options.hadoopConf)
+
+  def toInputFile(conf: Configuration): InputFile = HadoopInputFile.fromPath(hadoopPath, conf)
+
+  def toInputFile(options: ParquetReader.Options): InputFile = HadoopInputFile.fromPath(hadoopPath, options.hadoopConf)
 
   override def equals(other: Any): Boolean = other match {
     case that: Path =>

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/FileStats.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/FileStats.scala
@@ -16,10 +16,10 @@ import scala.jdk.CollectionConverters.*
 private[parquet4s] object FileStats {
   def apply(
       status: FileStatus,
-      vcc: ValueCodecConfiguration,
       hadoopConf: Configuration,
+      vcc: ValueCodecConfiguration,
       projectionSchemaOpt: Option[MessageType]
-  ) =
+  ): Stats =
     new FileStats(HadoopInputFile.fromStatus(status, hadoopConf), vcc, projectionSchemaOpt)
 }
 

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/FilteredFileStats.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/FilteredFileStats.scala
@@ -8,23 +8,31 @@ import org.apache.parquet.filter2.compat.FilterCompat
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.util.HadoopInputFile
 import org.apache.parquet.io.api.*
-import org.apache.parquet.io.{ColumnIOFactory, MessageColumnIO}
+import org.apache.parquet.io.{ColumnIOFactory, InputFile, MessageColumnIO}
 import org.apache.parquet.schema.{GroupType, MessageType}
 
 import scala.annotation.tailrec
 import scala.jdk.CollectionConverters.*
 
+private[parquet4s] object FilteredFileStats {
+  def apply(
+      status: FileStatus,
+      hadoopConf: Configuration,
+      vcc: ValueCodecConfiguration,
+      projectionSchemaOpt: Option[MessageType],
+      filter: FilterCompat.Filter
+  ) = new FilteredFileStats(HadoopInputFile.fromStatus(status, hadoopConf), vcc, projectionSchemaOpt, filter)
+}
+
 /** Calculates statistics from <b>filtered</b> Parquet files.
   */
 private[parquet4s] class FilteredFileStats(
-    status: FileStatus,
+    inputFile: InputFile,
     vcc: ValueCodecConfiguration,
-    hadoopConf: Configuration,
     projectionSchemaOpt: Option[MessageType],
     filter: FilterCompat.Filter
 ) extends Stats {
 
-  private val inputFile     = HadoopInputFile.fromStatus(status, hadoopConf)
   private val readerOptions = ParquetReadOptions.builder().withRecordFilter(filter).build()
 
   abstract private class StatsReader {

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/LazyDelegateStats.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/LazyDelegateStats.scala
@@ -4,25 +4,37 @@ import com.github.mjakubowski84.parquet4s.*
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.filter2.compat.FilterCompat
 import org.apache.parquet.filter2.compat.FilterCompat.NoOpFilter
+import org.apache.parquet.hadoop.util.HadoopInputFile
+import org.apache.parquet.io.InputFile
 import org.apache.parquet.schema.MessageType
 
 private[parquet4s] class LazyDelegateStats(
-    path: Path,
+    inputFile: InputFile,
     vcc: ValueCodecConfiguration,
     hadoopConf: Configuration,
     projectionSchemaOpt: Option[MessageType],
     filter: FilterCompat.Filter
 ) extends Stats {
   private lazy val delegate: Stats = {
-    val fs = path.toHadoop.getFileSystem(hadoopConf)
-    val statsArray = fs.listStatus(path.toHadoop).map {
-      case status if filter.isInstanceOf[NoOpFilter] =>
-        FileStats(status, vcc, hadoopConf, projectionSchemaOpt)
-      case status =>
-        new FilteredFileStats(status, vcc, hadoopConf, projectionSchemaOpt, filter)
+    inputFile match {
+      case hadoopInputFile: HadoopInputFile =>
+        val hadoopPath = hadoopInputFile.getPath
+        val fs         = hadoopPath.getFileSystem(hadoopConf)
+        val statsArray = fs.listStatus(hadoopPath).map {
+          case status if filter.isInstanceOf[NoOpFilter] =>
+            FileStats(status, hadoopConf, vcc, projectionSchemaOpt)
+          case status =>
+            FilteredFileStats(status, hadoopConf, vcc, projectionSchemaOpt, filter)
+        }
+        if (statsArray.length == 1) statsArray.head
+        else new CompoundStats(statsArray.toIndexedSeq)
+      case _ if filter.isInstanceOf[NoOpFilter] =>
+        new FileStats(inputFile, vcc, projectionSchemaOpt)
+      case _ =>
+        new FilteredFileStats(inputFile, vcc, projectionSchemaOpt, filter)
+
     }
-    if (statsArray.length == 1) statsArray.head
-    else new CompoundStats(statsArray.toIndexedSeq)
+
   }
 
   override def recordCount: Long = delegate.recordCount

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/InMemoryFileSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/InMemoryFileSpec.scala
@@ -12,13 +12,13 @@ class InMemoryFileSpec extends AnyFlatSpec with Matchers {
 
     val count = 100
     val data  = (1 to count).map(i => Data(id = i, text = RandomStringUtils.randomPrint(4)))
-    val file  = InMemoryOutputFile.create("test")
+    val file  = InMemoryOutputFile("test")
 
     // write
     ParquetWriter.of[Data].writeAndClose(file, data)
 
     val inputFile = Files.createTempFile("in-memory-output-file-test", ".parquet")
-    Files.write(inputFile, file.toByteArray())
+    Files.write(inputFile, file.toByteArray)
 
     // read
     val readData = ParquetReader.as[Data].read(Path(inputFile))
@@ -31,12 +31,12 @@ class InMemoryFileSpec extends AnyFlatSpec with Matchers {
 
     val count      = 100
     val data       = (1 to count).map(i => Data(id = i, text = RandomStringUtils.randomPrint(4)))
-    val outputFile = InMemoryOutputFile.create("test")
+    val outputFile = InMemoryOutputFile("test")
 
     // write
     ParquetWriter.of[Data].writeAndClose(outputFile, data)
 
-    val inputFile = InMemoryInputFile.fromBytesUnsafe(outputFile.toByteArray())
+    val inputFile = InMemoryInputFile.fromBytesUnsafe(outputFile.toByteArray)
 
     // read
     val readData = ParquetReader.as[Data].read(inputFile)

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetIteratorSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/ParquetIteratorSpec.scala
@@ -2,7 +2,6 @@ package com.github.mjakubowski84.parquet4s
 
 import com.github.mjakubowski84.parquet4s
 import com.github.mjakubowski84.parquet4s.ValueImplicits.*
-import org.apache.parquet.hadoop.ParquetReader as HadoopParquetReader
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -15,14 +14,14 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
 
   private def mock[T: ClassTag]: T = org.mockito.Mockito.mock(classTag[T].runtimeClass).asInstanceOf[T]
 
-  private def mockTestBuilder(reader: HadoopParquetReader[RowParquetRecord]) = {
+  private def mockTestBuilder(reader: org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]) = {
     val builder = mock[parquet4s.ParquetIterator.HadoopBuilder]
     when(builder.build()).thenReturn(reader)
     builder
   }
 
   "hasNext" should "return false for empty resource" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(null)
 
     new ParquetIterator(mockTestBuilder(reader)).hasNext should be(false)
@@ -31,7 +30,7 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return true for single-record resource" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(testRecord(1))
 
     new ParquetIterator(mockTestBuilder(reader)).hasNext should be(true)
@@ -40,7 +39,7 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "call 'read' when it is called itself multiple times in sequence (and return false)" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(null)
 
     val iterator = new ParquetIterator(mockTestBuilder(reader))
@@ -52,7 +51,7 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "call 'read' when it is called itself multiple times in sequence (and return true)" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(testRecord(1))
 
     val iterator = new ParquetIterator(mockTestBuilder(reader))
@@ -64,21 +63,21 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   "next" should "return row for single-record resource" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(testRecord(1))
 
     new ParquetIterator(mockTestBuilder(reader)).next() should be(testRecord(1))
   }
 
   it should "throw NoSuchElementException for empty resource" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(null)
 
     a[NoSuchElementException] should be thrownBy new ParquetIterator(mockTestBuilder(reader)).next()
   }
 
   it should "try to read record only once in case of sequential calls for missing record" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(null)
 
     val iterator = new ParquetIterator(mockTestBuilder(reader))
@@ -90,7 +89,7 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "read next records until there so no more with subsequent calls" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read())
       .thenReturn(testRecord(1))
       .thenReturn(testRecord(2))
@@ -105,7 +104,7 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "not call 'read' if 'hasNext' already did it (and throw exception)" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(null)
 
     val iterator = new ParquetIterator(mockTestBuilder(reader))
@@ -116,7 +115,7 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "not call 'read' if 'hasNext' already did it (and return record)" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(testRecord(1))
 
     val iterator = new ParquetIterator(mockTestBuilder(reader))
@@ -127,7 +126,7 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "not call 'read' if 'hasNext' already did it (return the only available record)" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read())
       .thenReturn(testRecord(1))
       .thenReturn(null)
@@ -142,7 +141,7 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "not call 'read' if 'hasNext' already did it (return two available records)" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read())
       .thenReturn(testRecord(1))
       .thenReturn(testRecord(2))
@@ -160,7 +159,7 @@ class ParquetIteratorSpec extends AnyFlatSpec with Matchers {
   }
 
   "close" should "close the wrapped reader" in {
-    val reader = mock[HadoopParquetReader[RowParquetRecord]]
+    val reader = mock[org.apache.parquet.hadoop.ParquetReader[RowParquetRecord]]
     when(reader.read()).thenReturn(null)
 
     new ParquetIterator(mockTestBuilder(reader)).close()

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/PartitionFilterSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/PartitionFilterSpec.scala
@@ -4,6 +4,7 @@ import com.github.mjakubowski84.parquet4s.FilterRewriter.{IsFalse, IsTrue}
 import com.github.mjakubowski84.parquet4s.PartitionFilterRewriter.AssumeTrue
 import com.github.mjakubowski84.parquet4s.PartitionFilterSpec.IsUppercase
 import org.apache.commons.lang3.StringUtils
+import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.filter2.compat.FilterCompat
 import org.apache.parquet.filter2.compat.FilterCompat.FilterPredicateCompat
 import org.apache.parquet.filter2.predicate.FilterApi.{
@@ -56,9 +57,10 @@ class PartitionFilterSpec extends AnyFlatSpec with Matchers with Inside with Eit
   val case4: FilterPredicate = NOT(OR(eqi, neqj))
 
   val vcc: ValueCodecConfiguration = ValueCodecConfiguration.Default
+  val configuration                = new Configuration()
 
   def partitionedPath(partitions: (ColumnPath, String)*): PartitionedPath =
-    PartitionedPath(Path("/"), partitions.toList)
+    PartitionedPath(Path("/"), configuration, partitions.toList)
 
   def partitionedDirectory(partitionedPaths: PartitionedPath*): PartitionedDirectory =
     PartitionedDirectory(partitionedPaths).value


### PR DESCRIPTION
@huajiang-tubi This PR adds a missing part that was not addressed in #302:
 - Support for `InputFile` and `OutputFile` in FS2
 - Support for `InputFile` in Akka
 - Deeper integration of `InputFile` for reading partitions
 - Using `InputFile` in `Stats`

Can you check it out?