### PR TITLE
Feat(core): make path filter configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 spark-warehouse
 project/.plugins.sbt.swp
 project/project
+project/metals.sbt

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
@@ -1,12 +1,17 @@
 package com.github.mjakubowski84.parquet4s
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileAlreadyExistsException, FileStatus, FileSystem, RemoteIterator}
+import org.apache.hadoop.fs.FileAlreadyExistsException
+import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.PathFilter
+import org.apache.hadoop.fs.RemoteIterator
 import org.apache.parquet.hadoop.ParquetFileWriter
 import org.apache.parquet.hadoop.util.HiddenFileFilter
 import org.slf4j.Logger
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.util.matching.Regex
 
 private[parquet4s] object IOOps {
@@ -66,13 +71,17 @@ trait IOOps {
           .toList
       }
     }
-
+  /**
+   * @param path a location in a file tree from which `findPartitionedPaths` collects descendant paths recursively
+   * @param pathFilter  `findPartitionedPaths` traverses paths that match this predicate
+  */
   protected def findPartitionedPaths(
       path: Path,
-      configuration: Configuration
+      configuration: Configuration,
+      pathFilter: PathFilter = HiddenFileFilter.INSTANCE
   ): Either[Exception, PartitionedDirectory] = {
     val fs = path.toHadoop.getFileSystem(configuration)
-    findPartitionedPaths(fs, configuration, path, List.empty).fold(
+    findPartitionedPaths(fs, configuration, path, pathFilter, List.empty).fold(
       PartitionedDirectory.failed,
       PartitionedDirectory.apply
     )
@@ -82,10 +91,11 @@ trait IOOps {
       fs: FileSystem,
       configuration: Configuration,
       path: Path,
+      pathFilter: PathFilter,
       partitions: List[Partition]
   ): Either[List[Path], List[PartitionedPath]] = {
     val (dirs, files) = fs
-      .listStatus(path.toHadoop, HiddenFileFilter.INSTANCE)
+      .listStatus(path.toHadoop, pathFilter)
       .toList
       .partition(_.isDirectory)
     if (dirs.nonEmpty && files.nonEmpty)
@@ -96,11 +106,11 @@ trait IOOps {
         Right(List.empty) // empty leaf dir
       else if (partitionedDirs.isEmpty)
         // leaf files
-        Right(files.map(fileStatus => PartitionedPath(fileStatus, configuration, partitions)))
+        Right(files.map(PartitionedPath(_, configuration, partitions)))
       else
         partitionedDirs
           .map { case (subPath, partition) =>
-            findPartitionedPaths(fs, configuration, subPath, partitions :+ partition)
+            findPartitionedPaths(fs, configuration, subPath, pathFilter, partitions :+ partition)
           }
           .foldLeft[Either[List[Path], List[PartitionedPath]]](Right(List.empty)) {
             case (Left(invalidPaths), Left(moreInvalidPaths)) =>

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,6 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.11")
-


### PR DESCRIPTION
This change adds a pathFilter option to ParquetReader builder interface
because there are some situations where users needs to configure path filter
predicates(e.g. They use `_` prefix for partition columns).

Currently, there seems no options to change default path filter(`org.apache.parquet.hadoop.util.HiddenFileFilter`)