### PR TITLE
chore(core): use extends AnyVal for wrapper class

### DIFF
--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/Path.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/Path.scala
@@ -24,7 +24,7 @@ object Path {
 
 /** Represents path/URI to Parquet file or directory containing Parquet files.
   */
-class Path private (val hadoopPath: HadoopPath) {
+class Path private (val hadoopPath: HadoopPath) extends AnyVal {
 
   def append(element: String): Path = new Path(new HadoopPath(hadoopPath, element))
 
@@ -47,15 +47,6 @@ class Path private (val hadoopPath: HadoopPath) {
   def toInputFile(conf: Configuration): InputFile = HadoopInputFile.fromPath(hadoopPath, conf)
 
   def toInputFile(options: ParquetReader.Options): InputFile = HadoopInputFile.fromPath(hadoopPath, options.hadoopConf)
-
-  override def equals(other: Any): Boolean = other match {
-    case that: Path =>
-      (that canEqual this) &&
-        hadoopPath == that.toHadoop
-    case _ => false
-  }
-
-  override def hashCode(): Int = hadoopPath.hashCode()
 
   override def toString: String = hadoopPath.toString
 


### PR DESCRIPTION
Path seems a thin wrapper for hs.Path. I think it is better to extends AnyVal.
Is there any reason not to do that?

Refs
- https://docs.scala-lang.org/sips/value-classes.html
- https://docs.scala-lang.org/overviews/core/value-classes.html