### PR TITLE
Add codecs for Instant. Fix Nanos format for Timestamp and LocalDateTime

### DIFF
--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/Schema.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/Schema.scala
@@ -305,6 +305,9 @@ trait TimeValueSchemaDefs {
   implicit val localDateTimeSchema: TypedSchemaDef[java.time.LocalDateTime] =
     SchemaDef.primitive(INT96, required = false).withMetadata(SchemaDef.Meta.Generated).typed[java.time.LocalDateTime]
 
+  implicit val instantSchema: TypedSchemaDef[java.time.Instant] =
+    SchemaDef.primitive(INT96, required = false).withMetadata(SchemaDef.Meta.Generated).typed[java.time.Instant]
+
   implicit val sqlTimestampSchema: TypedSchemaDef[java.sql.Timestamp] =
     SchemaDef.primitive(INT96, required = false).withMetadata(SchemaDef.Meta.Generated).typed[java.sql.Timestamp]
 }

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/TimestampFormatSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/TimestampFormatSpec.scala
@@ -1,0 +1,86 @@
+package com.github.mjakubowski84.parquet4s
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.sql.Timestamp
+import java.time.{Instant, LocalDateTime}
+import java.util.TimeZone
+
+class TimestampFormatSpec extends AnyFlatSpec with Matchers {
+  private val defaultConfiguration = ValueCodecConfiguration(TimeZone.getTimeZone("Africa/Nairobi"))
+
+  behavior of "TimestampFormat.Implicits.Millis"
+
+  it should "be able to encode Instant and decode it back" in {
+    import TimestampFormat.Implicits.Millis.*
+    val instant        = Instant.ofEpochMilli(1234567L)
+    val decodedInstant = codec(instant)
+    decodedInstant should be(instant)
+  }
+
+  it should "be able to encode LocalDateTime and decode it back" in {
+    import TimestampFormat.Implicits.Millis.*
+    val dateTime        = LocalDateTime.of(2000, 1, 2, 3, 4, 5, 6000000)
+    val decodedDateTime = codec(dateTime)
+    decodedDateTime should be(dateTime)
+  }
+
+  it should "be able to encode Timestamp and decode it back" in {
+    import TimestampFormat.Implicits.Millis.*
+    val timestamp        = Timestamp.from(Instant.ofEpochMilli(1234567L))
+    val decodedTimestamp = codec(timestamp)
+    decodedTimestamp should be(timestamp)
+  }
+
+  behavior of "TimestampFormat.Implicits.Micros"
+
+  it should "be able to encode Instant and decode it back" in {
+    import TimestampFormat.Implicits.Micros.*
+    val instant        = Instant.ofEpochSecond(1234567L, 123000L)
+    val decodedInstant = codec(instant)
+    decodedInstant should be(instant)
+  }
+
+  it should "be able to encode LocalDateTime and decode it back" in {
+    import TimestampFormat.Implicits.Micros.*
+    val dateTime        = LocalDateTime.of(2000, 1, 2, 3, 4, 5, 678000)
+    val decodedDateTime = codec(dateTime)
+    decodedDateTime should be(dateTime)
+  }
+
+  it should "be able to encode Timestamp and decode it back" in {
+    import TimestampFormat.Implicits.Micros.*
+    val timestamp        = Timestamp.from(Instant.ofEpochSecond(1234567L, 123000L))
+    val decodedTimestamp = codec(timestamp)
+    decodedTimestamp should be(timestamp)
+  }
+
+  behavior of "TimestampFormat.Implicits.Nanos"
+
+  it should "be able to encode Instant and decode it back" in {
+    import TimestampFormat.Implicits.Nanos.*
+    val instant        = Instant.ofEpochSecond(1234567L, 1234567L)
+    val decodedInstant = codec(instant)
+    decodedInstant should be(instant)
+  }
+
+  it should "be able to encode LocalDateTime and decode it back" in {
+    import TimestampFormat.Implicits.Nanos.*
+    val dateTime        = LocalDateTime.of(2000, 1, 2, 3, 4, 5, 6789)
+    val decodedDateTime = codec(dateTime)
+    decodedDateTime should be(dateTime)
+  }
+
+  it should "be able to encode Timestamp and decode it back" in {
+    import TimestampFormat.Implicits.Nanos.*
+    val timestamp        = Timestamp.from(Instant.ofEpochSecond(1234567L, 1234567L))
+    val decodedTimestamp = codec(timestamp)
+    decodedTimestamp should be(timestamp)
+  }
+
+  private def codec[A](a: A)(implicit encoder: ValueEncoder[A], decoder: ValueDecoder[A]): A = {
+    val value = encoder.encode(a, defaultConfiguration)
+    decoder.decode(value, defaultConfiguration)
+  }
+}

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/ValueCodecsSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/ValueCodecsSpec.scala
@@ -1,0 +1,24 @@
+package com.github.mjakubowski84.parquet4s
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+import java.util.TimeZone
+
+class ValueCodecsSpec extends AnyFlatSpec with Matchers {
+  private val defaultConfiguration = ValueCodecConfiguration(TimeZone.getTimeZone("Africa/Nairobi"))
+
+  behavior of "Default timestamp format (INT96)"
+
+  it should "be able to encode Instant and decode it back" in {
+    val instant        = Instant.ofEpochMilli(1234567L)
+    val decodedInstant = codec(instant)
+    decodedInstant should be(instant)
+  }
+
+  private def codec[A](a: A)(implicit encoder: ValueEncoder[A], decoder: ValueDecoder[A]): A = {
+    val value = encoder.encode(a, defaultConfiguration)
+    decoder.decode(value, defaultConfiguration)
+  }
+}

--- a/site/src/main/resources/docs/docs/records_and_schema.md
+++ b/site/src/main/resources/docs/docs/records_and_schema.md
@@ -37,6 +37,8 @@ If you do not wish to map the schema of your data to Scala case classes, then Pa
 | BigDecimal                            |      &#x2611;       | &#x2611;  |
 | java.time.LocalDateTime [*with INT96] |      &#x2611;       | &#x2612;  |
 | java.time.LocalDateTime [*with INT64] |      &#x2611;       | &#x2611;  |
+| java.time.Instant [*with INT96]       |      &#x2611;       | &#x2612;  |
+| java.time.Instant [*with INT64]       |      &#x2611;       | &#x2611;  |
 | java.time.LocalDate                   |      &#x2611;       | &#x2611;  |
 | java.sql.Timestamp [*with INT96]      |      &#x2611;       | &#x2612;  |
 | java.sql.Timestamp [*with INT64]      |      &#x2611;       | &#x2611;  |


### PR DESCRIPTION
Currently, parquet4s has codecs for a `LocalDateTime` and `Timestamp` but lacks codecs for an `Instant`. That's unfair, as for me :) 

This PR adds codecs for an `Instant`. Also, it fixes a bit the `Nanos` format for a `Timestamp` and `LocalDateTime`.