### PR TITLE
Expose partitions as a nested Stream for FS2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.8

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -2,5 +2,5 @@
 
 // This file enables sbt-bloop to create bloop config files.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.11")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.13")
 


### PR DESCRIPTION
This change allows transformations to be applied per partition and makes it easier to execute in parallel

```scala
final case class AppEvent(eventName: String, eventValue: String, date: String, hour: String)

val readRecords: Stream[Task, InAppS3Event] =
  fromParquet[Task]
    .projectedGeneric(
      Col("event_name").as[String].alias("eventName"),
      Col("event_value").as[String].alias("eventValue"),
    )
    .chunkSize(1024)
    .filter(
      Col("date") >= "2024-01-20" &&
        Col("event_name") === "example",
    )
    .readPartitioned(Path("s3a://example/data/parquet/")) // new API
    .map(_.mapChunks(_.map(_.as[AppEvent](ValueCodecConfiguration.Default))))
    .parJoinUnbounded

val run: Task[Unit] =
  readRecords.compile.count.timed.debug.unit
```

Execution time: 24s

The older implementation:
```scala
val readRecords: Stream[Task, AppEvent] =
  fromParquet[Task]
    .projectedGeneric(
      Col("event_name").as[String].alias("eventName"),
      Col("event_value").as[String].alias("eventValue"),
    )
    .chunkSize(1024)
    .filter(
      Col("date") >= "2024-01-20" &&
        Col("event_name") === "example",
    )
    .read(Path("s3a://example/data/parquet/"))
    .mapChunks(_.map(_.as[AppEvent](ValueCodecConfiguration.Default)))
```

Execution time: 1m 52s

Closes https://github.com/mjakubowski84/parquet4s/issues/336