### PR TITLE
Eager partition filtering. Record filters.

### DIFF
--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/RecordFilterSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/RecordFilterSpec.scala
@@ -1,0 +1,25 @@
+package com.github.mjakubowski84.parquet4s
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scala.util.Using
+
+class RecordFilterSpec extends AnyFlatSpec with Matchers {
+
+  private case class Data(i: Int)
+
+  private val data = (0 to 10).map(Data(_))
+
+  "RecordFilter" should "filter data by record index" in {
+    val outFile = InMemoryOutputFile(initBufferSize = 1024)
+    ParquetWriter.of[Data].writeAndClose(outFile, data)
+    val inFile = outFile.toInputFile
+    Using.resource(ParquetReader.as[Data].filter(RecordFilter(i => i >= 1 && i < 10)).read(inFile)) { iterable =>
+      val result = iterable.toVector
+      result should have size 9
+      result.head should be(Data(1))
+      result.last should be(Data(9))
+    }
+  }
+
+}

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/IOOps.scala
@@ -1,7 +1,9 @@
 package com.github.mjakubowski84.parquet4s
 
+import com.github.mjakubowski84.parquet4s.PartitionedPath.Partition
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FileStatus, FileSystem, RemoteIterator}
+import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.ParquetFileWriter
 import org.apache.parquet.hadoop.util.HiddenFileFilter
 import org.slf4j.Logger
@@ -16,8 +18,6 @@ private[parquet4s] object IOOps {
     override def next(): T        = wrapped.next()
   }
 
-  private type Partition = (ColumnPath, String)
-
   private[parquet4s] val PartitionRegexp: Regex = """([a-zA-Z0-9._]+)=([a-zA-Z0-9!?\-+_.,*'()&$@:;/ ]+)""".r
 
 }
@@ -30,6 +30,8 @@ trait IOOps {
 
   protected val logger: Logger
 
+  private def debug(message: => String): Unit = if (logger.isDebugEnabled) logger.debug(message)
+
   protected def validateWritePath(path: Path, writeOptions: ParquetWriter.Options): Unit = {
     val hadoopPath = path.toHadoop
     val fs         = hadoopPath.getFileSystem(writeOptions.hadoopConf)
@@ -38,15 +40,13 @@ trait IOOps {
         case false if writeOptions.writeMode == ParquetFileWriter.Mode.CREATE =>
           throw new FileAlreadyExistsException(s"File or directory already exists: $hadoopPath")
         case false =>
-          if (logger.isDebugEnabled)
-            logger.debug(s"Deleting file $hadoopPath in order to override with new data.")
+          debug(s"Deleting file $hadoopPath in order to override with new data.")
           fs.delete(hadoopPath, true)
           ()
         case true if writeOptions.writeMode == ParquetFileWriter.Mode.CREATE =>
           ()
         case true =>
-          if (logger.isDebugEnabled)
-            logger.debug(s"Deleting directory $hadoopPath in order to override with new data.")
+          debug(s"Deleting directory $hadoopPath in order to override with new data.")
           fs.delete(hadoopPath, true)
           ()
       }
@@ -67,42 +67,99 @@ trait IOOps {
       }
     }
 
+  @deprecated(message = "Use listPartitionedDirectory instead", since = "2.17.0")
   protected def findPartitionedPaths(
       path: Path,
       configuration: Configuration
+  ): Either[Exception, PartitionedDirectory] =
+    listPartitionedDirectory(path, configuration, Filter.noopFilter, ValueCodecConfiguration.Default)
+
+  /** Traverses a tree of files which may cointain Hive-style partitions. Applies a provider filter to paths to
+    * eliminate redundant list operations on unmatched directories. The resulting [[PartitionedDirectory]] contains a
+    * list of all matching paths accompanied with a rewritten, simplified filter so that file filter does not contain
+    * references to partition fields.
+    *
+    * @param path
+    *   directory path
+    * @param configuration
+    *   Hadoop's [[org.apache.hadoop.conf.Configuration]]
+    * @param filter
+    *   filter to be applied to partitions and files
+    * @param valueCodecConfiguration
+    *   required to decode filter values
+    * @return
+    *   Exception or [[PartitionedDirectory]]
+    */
+  protected def listPartitionedDirectory(
+      path: Path,
+      configuration: Configuration,
+      filter: Filter,
+      valueCodecConfiguration: ValueCodecConfiguration
   ): Either[Exception, PartitionedDirectory] = {
+    val filterPredicateOpt = filter match {
+      case _: RecordFilter | Filter.noopFilter => None
+      case filter                              => Option(filter.toPredicate(valueCodecConfiguration))
+    }
     val fs = path.toHadoop.getFileSystem(configuration)
-    findPartitionedPaths(fs, configuration, path, List.empty).fold(
+    listPartitionedDirectory(fs, configuration, path, List.empty, filterPredicateOpt).fold(
       PartitionedDirectory.failed,
       PartitionedDirectory.apply
     )
   }
 
-  private def findPartitionedPaths(
+  private def listPartitionedDirectory(
       fs: FileSystem,
       configuration: Configuration,
       path: Path,
-      partitions: List[Partition]
-  ): Either[List[Path], List[PartitionedPath]] = {
+      partitions: List[Partition],
+      filterPredicateOpt: Option[FilterPredicate]
+  ): Either[Vector[Path], Vector[PartitionedPath]] = {
     val (dirs, files) = fs
       .listStatus(path.toHadoop, HiddenFileFilter.INSTANCE)
-      .toList
+      .toVector
       .partition(_.isDirectory)
     if (dirs.nonEmpty && files.nonEmpty)
-      Left(path :: Nil) // path is invalid because it contains both dirs and files
+      Left(Vector(path)) // path is invalid because it contains both dirs and files
     else {
       val partitionedDirs = dirs.flatMap(matchPartition)
       if (partitionedDirs.isEmpty && files.isEmpty)
-        Right(List.empty) // empty leaf dir
-      else if (partitionedDirs.isEmpty)
+        Right(Vector.empty) // empty dir
+      else if (partitionedDirs.isEmpty) {
         // leaf files
-        Right(files.map(fileStatus => PartitionedPath(fileStatus, configuration, partitions)))
-      else
-        partitionedDirs
-          .map { case (subPath, partition) =>
-            findPartitionedPaths(fs, configuration, subPath, partitions :+ partition)
+        filterPredicateOpt match {
+          case None =>
+            Right(files.map(fileStatus => PartitionedPath(fileStatus, configuration, partitions, filterPredicateOpt)))
+          case Some(filterPredicate) =>
+            FilterRewriter.rewrite(filterPredicate, PartitionView(partitions)) match {
+              case FilterRewriter.IsTrue =>
+                debug(s"Dropping filter at path $path as partition exhausts filter predicate $filterPredicate.")
+                Right(files.map(fileStatus => PartitionedPath(fileStatus, configuration, partitions, None)))
+              case FilterRewriter.IsFalse =>
+                debug(s"Skipping files at path $path as partition does not match filter predicate $filterPredicate.")
+                Right(Vector.empty)
+              case rewritten =>
+                debug(s"Filter predicate $filterPredicate for path $path has been rewritten to $rewritten.")
+                Right(
+                  files.map(fileStatus => PartitionedPath(fileStatus, configuration, partitions, Option(rewritten)))
+                )
+            }
+        }
+      } else {
+        // non-empty node dir
+        // early removes paths which do not match filter predicate
+        filterPredicateOpt
+          .fold(partitionedDirs.map { case (path, partition) => path -> (partitions :+ partition) }) {
+            filterPredicate =>
+              PartitionFilter.filterPartitionPaths(
+                filterPredicate  = filterPredicate,
+                commonPartitions = partitions,
+                partitionedPaths = partitionedDirs
+              )
           }
-          .foldLeft[Either[List[Path], List[PartitionedPath]]](Right(List.empty)) {
+          .map { case (subPath, partitions) =>
+            listPartitionedDirectory(fs, configuration, subPath, partitions, filterPredicateOpt)
+          }
+          .foldLeft[Either[Vector[Path], Vector[PartitionedPath]]](Right(Vector.empty)) {
             case (Left(invalidPaths), Left(moreInvalidPaths)) =>
               Left(invalidPaths ++ moreInvalidPaths)
             case (Right(partitionedPaths), Right(morePartitionedPaths)) =>
@@ -112,6 +169,7 @@ trait IOOps {
             case (_, left: Left[?, ?]) =>
               left
           }
+      }
     }
   }
 

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetIterable.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetIterable.scala
@@ -166,7 +166,7 @@ trait ParquetIterable[T] extends Iterable[T] with Closeable {
     *   dataset to be concatenated with this
     */
   @experimental
-  def concat(other: ParquetIterable[T]): ParquetIterable[T] = new CompoundParquetIterable(Seq(this, other))
+  def concat(other: ParquetIterable[T]): ParquetIterable[T] = new CompoundParquetIterable(Iterable(this, other))
 
   /** Writes this dataset to given <i>path</i> and releases all opened resources.
     * @param path

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/etl/CompoundParquetIterable.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/etl/CompoundParquetIterable.scala
@@ -3,7 +3,8 @@ package com.github.mjakubowski84.parquet4s.etl
 import com.github.mjakubowski84.parquet4s.*
 import com.github.mjakubowski84.parquet4s.stats.CompoundStats
 
-private[parquet4s] class CompoundParquetIterable[T](components: Seq[ParquetIterable[T]]) extends ParquetIterable[T] {
+private[parquet4s] class CompoundParquetIterable[T](components: Iterable[ParquetIterable[T]])
+    extends ParquetIterable[T] {
 
   override val stats: Stats = new CompoundStats(components.map(_.stats))
 
@@ -24,5 +25,5 @@ private[parquet4s] class CompoundParquetIterable[T](components: Seq[ParquetItera
     new CompoundParquetIterable[U](components.map(_.changeDecoder[U]))
 
   override def concat(other: ParquetIterable[T]): ParquetIterable[T] =
-    new CompoundParquetIterable(components :+ other)
+    new CompoundParquetIterable(components ++ Iterable(other))
 }

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/CompoundStats.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/CompoundStats.scala
@@ -4,7 +4,7 @@ import com.github.mjakubowski84.parquet4s.{ColumnPath, Stats, ValueDecoder}
 
 /** Calculates [[Stats]] from multiple files.
   */
-private[parquet4s] class CompoundStats(statsSeq: Seq[Stats]) extends Stats {
+private[parquet4s] class CompoundStats(statsSeq: Iterable[Stats]) extends Stats {
 
   override lazy val recordCount: Long = statsSeq.map(_.recordCount).sum
 

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/LazyDelegateStats.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/stats/LazyDelegateStats.scala
@@ -27,7 +27,7 @@ private[parquet4s] class LazyDelegateStats(
             FilteredFileStats(status, hadoopConf, vcc, projectionSchemaOpt, filter)
         }
         if (statsArray.length == 1) statsArray.head
-        else new CompoundStats(statsArray.toIndexedSeq)
+        else new CompoundStats(statsArray)
       case _ if filter.isInstanceOf[NoOpFilter] =>
         new FileStats(inputFile, vcc, projectionSchemaOpt)
       case _ =>

--- a/core/src/test/scala/com/github/mjakubowski84/parquet4s/DecimalValueSpec.scala
+++ b/core/src/test/scala/com/github/mjakubowski84/parquet4s/DecimalValueSpec.scala
@@ -27,7 +27,7 @@ class DecimalValueSpec extends AnyFlatSpec with Matchers {
     val inputFile = outputFile.toInputFile
 
     // read
-    Using(ParquetReader.as[Data].read(inputFile)) { readData =>
+    Using.resource(ParquetReader.as[Data].read(inputFile)) { readData =>
       readData.toSeq shouldBe data
     }
   }
@@ -52,7 +52,7 @@ class DecimalValueSpec extends AnyFlatSpec with Matchers {
     val inputFile = outputFile.toInputFile
 
     // read
-    Using(ParquetReader.as[Data].read(inputFile)) { readData =>
+    Using.resource(ParquetReader.as[Data].read(inputFile)) { readData =>
       readData.toSeq shouldBe data
     }
   }

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/ColumnProjectionAndDataConcatenationApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/ColumnProjectionAndDataConcatenationApp.scala
@@ -4,6 +4,7 @@ import com.github.mjakubowski84.parquet4s.*
 
 import java.nio.file.Files
 import java.time.LocalDate
+import scala.util.Using
 
 object ColumnProjectionAndDataConcatenationApp extends App {
 
@@ -59,7 +60,6 @@ object ColumnProjectionAndDataConcatenationApp extends App {
   val readAllUserNames = readUsers1.concat(readUsers2)
 
   // execute
-  try readAllUserNames.foreach(println)
-  finally readAllUserNames.close()
+  Using.resource(readAllUserNames)(_.foreach(println))
 
 }

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteAndReadCustomTypeApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteAndReadCustomTypeApp.scala
@@ -5,6 +5,7 @@ import com.github.mjakubowski84.parquet4s.ParquetSchemaResolver.*
 import com.github.mjakubowski84.parquet4s.{ParquetReader, ParquetWriter, Path}
 
 import java.nio.file.Files
+import scala.util.Using
 
 object WriteAndReadCustomTypeApp extends App {
 
@@ -20,9 +21,7 @@ object WriteAndReadCustomTypeApp extends App {
   ParquetWriter.of[Data].writeAndClose(path.append("data.parquet"), data)
 
   // read
-  val readData = ParquetReader.as[Data].read(path)
   // hint: you can filter by dict using string value, for example: filter = Col("dict") === "A"
-  try readData.foreach(println)
-  finally readData.close()
+  Using.resource(ParquetReader.as[Data].read(path))(_.foreach(println))
 
 }

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteAndReadFilteredApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteAndReadFilteredApp.scala
@@ -4,6 +4,7 @@ import com.github.mjakubowski84.parquet4s.{Col, ParquetReader, ParquetWriter, Pa
 
 import java.nio.file.Files
 import scala.util.Random
+import scala.util.Using
 
 object WriteAndReadFilteredApp extends App {
 
@@ -29,12 +30,10 @@ object WriteAndReadFilteredApp extends App {
   // read filtered
   println("""dict == "A"""")
   val dictIsOnlyA = ParquetReader.as[Data].filter(Col("dict") === Dict.A).read(path)
-  try dictIsOnlyA.foreach(println)
-  finally dictIsOnlyA.close()
+  Using.resource(dictIsOnlyA)(_.foreach(println))
 
   println("""id >= 20 && id < 40""")
   val idIsBetween10And90 = ParquetReader.as[Data].filter(Col("id") >= 20 && Col("id") < 40).read(path)
-  try idIsBetween10And90.foreach(println)
-  finally idIsBetween10And90.close()
+  Using.resource(idIsBetween10And90)(_.foreach(println))
 
 }

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteAndReadGenericApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteAndReadGenericApp.scala
@@ -7,6 +7,7 @@ import org.apache.parquet.schema.{LogicalTypeAnnotation, MessageType, Types}
 
 import java.nio.file.Files
 import java.time.LocalDate
+import scala.util.Using
 
 object WriteAndReadGenericApp extends App {
 
@@ -41,12 +42,13 @@ object WriteAndReadGenericApp extends App {
   ParquetWriter.generic(schema).writeAndClose(path.append("users.parquet"), users)
 
   // read
-  val readData = ParquetReader.generic.read(path)
-  try readData.foreach { record =>
-    val id       = record.get[Long](ID, vcc)
-    val name     = record.get[String](Name, vcc)
-    val birthday = record.get[LocalDate](Birthday, vcc)
-    println(s"User[$ID=$id,$Name=$name,$Birthday=$birthday]")
-  } finally readData.close()
+  Using.resource(ParquetReader.generic.read(path)) { readData =>
+    readData.foreach { record =>
+      val id       = record.get[Long](ID, vcc)
+      val name     = record.get[String](Name, vcc)
+      val birthday = record.get[LocalDate](Birthday, vcc)
+      println(s"User[$ID=$id,$Name=$name,$Birthday=$birthday]")
+    }
+  }
 
 }

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteAndReadUsingRecordFilterApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteAndReadUsingRecordFilterApp.scala
@@ -5,8 +5,9 @@ import com.github.mjakubowski84.parquet4s.{ParquetReader, ParquetWriter, Path}
 import java.nio.file.Files
 import scala.util.Random
 import scala.util.Using
+import com.github.mjakubowski84.parquet4s.RecordFilter
 
-object WriteAndReadApp extends App {
+object WriteAndReadUsingRecordFilterApp extends App {
 
   case class Data(id: Int, text: String)
 
@@ -17,6 +18,6 @@ object WriteAndReadApp extends App {
   // write
   ParquetWriter.of[Data].writeAndClose(path.append("data.parquet"), data)
 
-  // read
-  Using.resource(ParquetReader.as[Data].read(path))(_.foreach(println))
+  // skips all but last 3 records (out of 100)
+  Using.resource(ParquetReader.as[Data].filter(RecordFilter(_ >= 97)).read(path))(_.foreach(println))
 }

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteIncrementallyAndReadApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/core/WriteIncrementallyAndReadApp.scala
@@ -4,6 +4,7 @@ import com.github.mjakubowski84.parquet4s.{ParquetReader, ParquetWriter, Path}
 
 import java.nio.file.Files
 import scala.util.Random
+import scala.util.Using
 
 object WriteIncrementallyAndReadApp extends App {
 
@@ -19,8 +20,6 @@ object WriteIncrementallyAndReadApp extends App {
   finally writer.close()
 
   // read
-  val readData = ParquetReader.as[Data].read(path)
-  try readData.foreach(println)
-  finally readData.close()
+  Using.resource(ParquetReader.as[Data].read(path))(_.foreach(println))
 
 }

--- a/examples/src/main/scala/com/github/mjakubowski84/parquet4s/scalapb/WriteAndReadApp.scala
+++ b/examples/src/main/scala/com/github/mjakubowski84/parquet4s/scalapb/WriteAndReadApp.scala
@@ -15,5 +15,5 @@ object WriteAndReadApp extends App {
   ParquetWriter.of[Data].writeAndClose(path.append("data.parquet"), data)
 
   // read
-  Using(ParquetReader.as[Data].read(path))(_.foreach(println))
+  Using.resource(ParquetReader.as[Data].read(path))(_.foreach(println))
 }

--- a/fs2/src/it/scala/com/github/mjakubowski84/parquet4s/parquet/IoITSpec.scala
+++ b/fs2/src/it/scala/com/github/mjakubowski84/parquet4s/parquet/IoITSpec.scala
@@ -2,7 +2,7 @@ package com.github.mjakubowski84.parquet4s.parquet
 
 import cats.effect.IO
 import cats.effect.testing.scalatest.AsyncIOSpec
-import com.github.mjakubowski84.parquet4s.{Col, ParquetWriter, PartitionedPath, Path}
+import com.github.mjakubowski84.parquet4s.{Col, Filter, ParquetWriter, PartitionedPath, Path, ValueCodecConfiguration}
 import fs2.Stream
 import fs2.io.file.*
 import org.apache.parquet.hadoop.ParquetFileWriter
@@ -20,6 +20,7 @@ class IoITSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers {
   private val writeOptions  = ParquetWriter.Options()
   private val configuration = writeOptions.hadoopConf
   private val fileName      = "file.parquet"
+  private val vcc           = ValueCodecConfiguration.Default
 
   private def createFileAtPath(path: Path): Stream[IO, Path] = {
     val filePath = path.append(fileName)
@@ -109,11 +110,11 @@ class IoITSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers {
     }
   }
 
-  "findPartitionedPaths" should "return empty PartitionedDirectory for empty path" in {
+  "listPartitionedDirectory" should "return empty PartitionedDirectory for empty path" in {
     val testStream = for {
       path   <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
       logger <- Stream.eval(logger[IO](getClass))
-      dir    <- io.findPartitionedPaths[IO](path, writeOptions.hadoopConf, logger)
+      dir    <- io.listPartitionedDirectory[IO](path, writeOptions.hadoopConf, logger, Filter.noopFilter, vcc)
     } yield {
       dir.schema should be(empty)
       dir.paths should be(empty)
@@ -127,10 +128,10 @@ class IoITSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers {
       basePath <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
       filePath <- createFileAtPath(basePath)
       logger   <- Stream.eval(logger[IO](getClass))
-      dir      <- io.findPartitionedPaths[IO](basePath, writeOptions.hadoopConf, logger)
+      dir      <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, Filter.noopFilter, vcc)
     } yield {
       dir.schema should be(empty)
-      dir.paths should be(Vector(PartitionedPath(filePath, configuration, List.empty)))
+      dir.paths should be(Vector(PartitionedPath(filePath, configuration, List.empty, None)))
     }
 
     testStream.compile.lastOrError
@@ -141,10 +142,10 @@ class IoITSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers {
       basePath      <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
       partitionPath <- createFileAtPath(basePath.append("x=1"))
       logger        <- Stream.eval(logger[IO](getClass))
-      dir           <- io.findPartitionedPaths[IO](basePath, writeOptions.hadoopConf, logger)
+      dir <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, Filter.noopFilter, vcc)
     } yield {
       dir.schema should be(List(Col("x")))
-      dir.paths should be(Vector(PartitionedPath(partitionPath, configuration, List(Col("x") -> "1"))))
+      dir.paths should be(Vector(PartitionedPath(partitionPath, configuration, List(Col("x") -> "1"), None)))
     }
 
     testStream.compile.lastOrError
@@ -155,10 +156,10 @@ class IoITSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers {
       basePath      <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
       partitionPath <- createFileAtPath(basePath.append("x=1"))
       logger        <- Stream.eval(logger[IO](getClass))
-      dir           <- io.findPartitionedPaths[IO](partitionPath, writeOptions.hadoopConf, logger)
+      dir <- io.listPartitionedDirectory[IO](partitionPath, writeOptions.hadoopConf, logger, Filter.noopFilter, vcc)
     } yield {
       dir.schema should be(empty)
-      dir.paths should be(Vector(PartitionedPath(partitionPath, configuration, List.empty)))
+      dir.paths should be(Vector(PartitionedPath(partitionPath, configuration, List.empty, None)))
     }
 
     testStream.compile.lastOrError
@@ -172,14 +173,14 @@ class IoITSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers {
       partition3 <- createFileAtPath(basePath.append("x=1/y=c/z=1_1"))
       partition4 <- createFileAtPath(basePath.append("x=2/y=b/z=1_2"))
       logger     <- Stream.eval(logger[IO](getClass))
-      dir        <- io.findPartitionedPaths[IO](basePath, writeOptions.hadoopConf, logger)
+      dir        <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, Filter.noopFilter, vcc)
     } yield {
       dir.schema should be(List(Col("x"), Col("y"), Col("z")))
       dir.paths should contain theSameElementsAs Vector(
-        PartitionedPath(partition1, configuration, List(Col("x") -> "1", Col("y") -> "a", Col("z") -> "0_9")),
-        PartitionedPath(partition2, configuration, List(Col("x") -> "1", Col("y") -> "b", Col("z") -> "1_0")),
-        PartitionedPath(partition3, configuration, List(Col("x") -> "1", Col("y") -> "c", Col("z") -> "1_1")),
-        PartitionedPath(partition4, configuration, List(Col("x") -> "2", Col("y") -> "b", Col("z") -> "1_2"))
+        PartitionedPath(partition1, configuration, List(Col("x") -> "1", Col("y") -> "a", Col("z") -> "0_9"), None),
+        PartitionedPath(partition2, configuration, List(Col("x") -> "1", Col("y") -> "b", Col("z") -> "1_0"), None),
+        PartitionedPath(partition3, configuration, List(Col("x") -> "1", Col("y") -> "c", Col("z") -> "1_1"), None),
+        PartitionedPath(partition4, configuration, List(Col("x") -> "2", Col("y") -> "b", Col("z") -> "1_2"), None)
       )
     }
 
@@ -192,7 +193,7 @@ class IoITSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers {
       _        <- createFileAtPath(basePath.append("x=1/y=a"))
       _        <- createFileAtPath(basePath.append("y=b/x=2"))
       logger   <- Stream.eval(logger[IO](getClass))
-      _        <- io.findPartitionedPaths[IO](basePath, writeOptions.hadoopConf, logger)
+      _        <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, Filter.noopFilter, vcc)
     } yield succeed
 
     testStream.compile.lastOrError.assertThrows[IllegalArgumentException]
@@ -204,10 +205,146 @@ class IoITSpec extends AsyncFlatSpec with AsyncIOSpec with Matchers {
       _        <- createFileAtPath(basePath.append("x=1/y=a"))
       _        <- createFileAtPath(basePath.append("x=1/y=a/z=0_9"))
       logger   <- Stream.eval(logger[IO](getClass))
-      _        <- io.findPartitionedPaths[IO](basePath, writeOptions.hadoopConf, logger)
+      _        <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, Filter.noopFilter, vcc)
     } yield succeed
 
     testStream.compile.lastOrError.assertThrows[IllegalArgumentException]
+  }
+
+  it should "be able to apply filter on empty directory" in {
+    val testStream = for {
+      basePath  <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
+      logger    <- Stream.eval(logger[IO](getClass))
+      directory <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, Col("x") === "1", vcc)
+    } yield {
+      directory.paths should be(empty)
+      directory.schema should be(empty)
+    }
+    testStream.compile.lastOrError
+  }
+
+  it should "be able to apply filter on non-partitioned directory" in {
+    val filter = Col("x") === "1"
+    val testStream = for {
+      basePath  <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
+      file1     <- createFileAtPath(basePath)
+      logger    <- Stream.eval(logger[IO](getClass))
+      directory <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, filter, vcc)
+    } yield {
+      directory.paths should contain theSameElementsAs (Seq(
+        PartitionedPath(file1, configuration, List.empty, Some(filter.toPredicate(vcc)))
+      ))
+      directory.schema should be(empty)
+    }
+    testStream.compile.lastOrError
+  }
+
+  it should "not filter partitions if the filter does not match their values" in {
+    val filter = Col("a") === "A"
+    val testStream = for {
+      basePath  <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
+      file1     <- createFileAtPath(basePath.append("x=1/y=10/z=100"))
+      file2     <- createFileAtPath(basePath.append("x=1/y=11/z=101"))
+      file3     <- createFileAtPath(basePath.append("x=2/y=12/z=100"))
+      logger    <- Stream.eval(logger[IO](getClass))
+      directory <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, filter, vcc)
+    } yield {
+      directory.paths should contain theSameElementsAs (
+        Seq(
+          PartitionedPath(
+            file1,
+            configuration,
+            List(Col("x") -> "1", Col("y") -> "10", Col("z") -> "100"),
+            Some(filter.toPredicate(vcc))
+          ),
+          PartitionedPath(
+            file2,
+            configuration,
+            List(Col("x") -> "1", Col("y") -> "11", Col("z") -> "101"),
+            Some(filter.toPredicate(vcc))
+          ),
+          PartitionedPath(
+            file3,
+            configuration,
+            List(Col("x") -> "2", Col("y") -> "12", Col("z") -> "100"),
+            Some(filter.toPredicate(vcc))
+          )
+        )
+      )
+      directory.schema should be(List(Col("x"), Col("y"), Col("z")))
+    }
+    testStream.compile.lastOrError
+  }
+
+  it should "rewrite a filter if partitions match the filter paertially" in {
+    val filter             = Col("x") === "1" && Col("a") === "A"
+    val rewrittenPredicate = (Col("a") === "A").toPredicate(vcc)
+    val testStream = for {
+      basePath  <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
+      file1     <- createFileAtPath(basePath.append("x=1/y=10/z=100"))
+      file2     <- createFileAtPath(basePath.append("x=1/y=11/z=101"))
+      _         <- createFileAtPath(basePath.append("x=2/y=12/z=100"))
+      logger    <- Stream.eval(logger[IO](getClass))
+      directory <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, filter, vcc)
+    } yield {
+      directory.paths should contain theSameElementsAs (
+        Seq(
+          PartitionedPath(
+            path               = file1,
+            configuration      = configuration,
+            partitions         = List(Col("x") -> "1", Col("y") -> "10", Col("z") -> "100"),
+            filterPredicateOpt = Some(rewrittenPredicate)
+          ),
+          PartitionedPath(
+            path               = file2,
+            configuration      = configuration,
+            partitions         = List(Col("x") -> "1", Col("y") -> "11", Col("z") -> "101"),
+            filterPredicateOpt = Some(rewrittenPredicate)
+          )
+        )
+      )
+      directory.schema should be(List(Col("x"), Col("y"), Col("z")))
+    }
+    testStream.compile.lastOrError
+  }
+
+  it should "drop a filter if partitions exhaust it" in {
+    val filter = Col("x") === "1" && Col("y") > "10"
+    val testStream = for {
+      basePath  <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
+      _         <- createFileAtPath(basePath.append("x=1/y=10/z=100"))
+      file2     <- createFileAtPath(basePath.append("x=1/y=11/z=101"))
+      _         <- createFileAtPath(basePath.append("x=2/y=12/z=100"))
+      logger    <- Stream.eval(logger[IO](getClass))
+      directory <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, filter, vcc)
+    } yield {
+      directory.paths should contain theSameElementsAs (Seq(
+        PartitionedPath(
+          path               = file2,
+          configuration      = configuration,
+          partitions         = List(Col("x") -> "1", Col("y") -> "11", Col("z") -> "101"),
+          filterPredicateOpt = None
+        )
+      ))
+      directory.schema should be(List(Col("x"), Col("y"), Col("z")))
+    }
+    testStream.compile.lastOrError
+  }
+
+  it should "return empty directory if no parition match the filter" in {
+    val filter = Col("x") === "4"
+    val testStream = for {
+      basePath  <- Stream.resource(Files[IO].tempDirectory(None, "", None).map(_.toPath))
+      _         <- createFileAtPath(basePath.append("x=1/y=10/z=100"))
+      _         <- createFileAtPath(basePath.append("x=1/y=11/z=101"))
+      _         <- createFileAtPath(basePath.append("x=2/y=12/z=100"))
+      logger    <- Stream.eval(logger[IO](getClass))
+      directory <- io.listPartitionedDirectory[IO](basePath, writeOptions.hadoopConf, logger, filter, vcc)
+    } yield {
+      directory.paths should be(empty)
+      directory.schema should be(empty)
+    }
+    testStream.compile.lastOrError
   }
 
 }

--- a/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/io.scala
+++ b/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/io.scala
@@ -1,10 +1,12 @@
 package com.github.mjakubowski84.parquet4s.parquet
 
 import cats.effect.Sync
-import com.github.mjakubowski84.parquet4s.{ColumnPath, ParquetWriter, PartitionedDirectory, PartitionedPath, Path}
+import com.github.mjakubowski84.parquet4s.*
 import org.apache.hadoop.fs.{FileAlreadyExistsException, FileStatus, FileSystem}
+import org.apache.parquet.filter2.predicate.FilterPredicate
 import org.apache.parquet.hadoop.ParquetFileWriter
 import cats.implicits.*
+import com.github.mjakubowski84.parquet4s.PartitionedPath.Partition
 import com.github.mjakubowski84.parquet4s.parquet.logger.Logger
 import org.apache.hadoop.conf.Configuration
 import fs2.Stream
@@ -13,8 +15,6 @@ import org.apache.parquet.hadoop.util.HiddenFileFilter
 import scala.util.matching.Regex
 
 private[parquet] object io {
-
-  private type Partition = (ColumnPath, String)
 
   sealed private trait StatusAccumulator
   private case object Empty extends StatusAccumulator
@@ -52,12 +52,52 @@ private[parquet] object io {
       }
   }
 
-  def findPartitionedPaths[F[_]](path: Path, configuration: Configuration, logger: Logger[F])(implicit
-      F: Sync[F]
-  ): Stream[F, PartitionedDirectory] =
-    Stream
-      .eval(F.blocking(path.toHadoop.getFileSystem(configuration)))
-      .flatMap(fs => findPartitionedPaths(fs, configuration, path, logger, List.empty))
+  @deprecated(message = "Use listPartitionedDirectory instead", since = "2.17.0")
+  def findPartitionedPaths[F[_]](
+      path: Path,
+      configuration: Configuration,
+      logger: Logger[F]
+  )(implicit F: Sync[F]): Stream[F, PartitionedDirectory] =
+    listPartitionedDirectory(path, configuration, logger, Filter.noopFilter, ValueCodecConfiguration.Default)
+
+  /** Traverses a tree of files which may cointain Hive-style partitions. Applies a provider filter to paths to
+    * eliminate redundant list operations on unmatched directories. The resulting [[PartitionedDirectory]] contains a
+    * list of all matching paths accompanied with a rewritten, simplified filter so that file filter does not contain
+    * references to partition fields.
+    *
+    * @param path
+    *   directory path
+    * @param configuration
+    *   Hadoop's [[org.apache.hadoop.conf.Configuration]]
+    * @param logger
+    *   logger
+    * @param filter
+    *   filter to be applied to partitions and files
+    * @param valueCodecConfiguration
+    *   required to decode filter value
+    * @param F
+    *   effect
+    * @return
+    *   [[fs2.Stream]] of single [[PartitionedDirectory]]
+    */
+  def listPartitionedDirectory[F[_]](
+      path: Path,
+      configuration: Configuration,
+      logger: Logger[F],
+      filter: Filter,
+      valueCodecConfiguration: ValueCodecConfiguration
+  )(implicit F: Sync[F]): Stream[F, PartitionedDirectory] = {
+    val filterPredicateOptStream = filter match {
+      case _: RecordFilter | Filter.noopFilter => Stream.emit(None)
+      case filter => Stream.eval(F.catchNonFatal(Option(filter.toPredicate(valueCodecConfiguration))))
+    }
+    val partitionedPathsStream = for {
+      filterPredicateOpt <- filterPredicateOptStream
+      fs                 <- Stream.eval(F.blocking(path.toHadoop.getFileSystem(configuration)))
+      partitionedPaths   <- listPartitionedDirectory(fs, configuration, path, logger, filterPredicateOpt, List.empty)
+    } yield partitionedPaths
+
+    partitionedPathsStream
       .fold[Either[Seq[Path], Seq[PartitionedPath]]](Right(Vector.empty)) {
         case (Left(invalidPaths), Left(moreInvalidPaths)) =>
           Left(invalidPaths ++ moreInvalidPaths)
@@ -73,12 +113,14 @@ private[parquet] object io {
         case Right(partitionedPaths) => PartitionedDirectory(partitionedPaths)
       }
       .flatMap(Stream.fromEither[F].apply)
+  }
 
-  private def findPartitionedPaths[F[_]](
+  private def listPartitionedDirectory[F[_]](
       fs: FileSystem,
       configuration: Configuration,
       path: Path,
       logger: Logger[F],
+      filterPredicateOpt: Option[FilterPredicate],
       partitions: List[Partition]
   )(implicit
       F: Sync[F]
@@ -101,12 +143,52 @@ private[parquet] object io {
       }
       .flatMap {
         case Dirs(partitionPaths) => // node of directory tree
-          Stream.emits(partitionPaths).flatMap { case (subPath, partition) =>
-            findPartitionedPaths(fs, configuration, subPath, logger, partitions :+ partition)
+          val partitionedDirs = filterPredicateOpt match {
+            case Some(filterPredicate) =>
+              // filters subPaths early
+              Stream.evalSeq(
+                F.catchNonFatal(PartitionFilter.filterPartitionPaths(filterPredicate, partitions, partitionPaths))
+              )
+            case None =>
+              Stream.iterable(partitionPaths).map { case (subPath, partition) => subPath -> (partitions :+ partition) }
+          }
+          partitionedDirs.flatMap { case (subPath, partitions) =>
+            listPartitionedDirectory(fs, configuration, subPath, logger, filterPredicateOpt, partitions)
           }
         case Files(files) => // leaf of directory tree
-          Stream.emit(Right(files.map(fileStatus => PartitionedPath(fileStatus, configuration, partitions))))
-        case Empty => // avoid redundant scans of empty dirs
+          filterPredicateOpt match {
+            case None =>
+              Stream.emit(Right(files.map(fileStatus => PartitionedPath(fileStatus, configuration, partitions, None))))
+            case Some(filterPredicate) =>
+              Stream
+                .eval(F.catchNonFatal(FilterRewriter.rewrite(filterPredicate, PartitionView(partitions))))
+                .evalMapChunk[F, Either[Seq[Path], Seq[PartitionedPath]]] {
+                  case FilterRewriter.IsTrue =>
+                    logger.debug(
+                      s"Dropping filter at path $path as partition exhausts filter predicate $filterPredicate."
+                    ) >>
+                      F.delay(
+                        Right(files.map(fileStatus => PartitionedPath(fileStatus, configuration, partitions, None)))
+                      )
+                  case FilterRewriter.IsFalse =>
+                    logger.debug(
+                      s"Skipping files at path $path as partition does not match filter predicate $filterPredicate."
+                    ) >>
+                      F.pure(Right(List.empty))
+                  case rewritten =>
+                    logger.debug(
+                      s"Filter predicate $filterPredicate for path $path has been rewritten to $rewritten."
+                    ) >>
+                      F.delay(
+                        Right(
+                          files.map(fileStatus =>
+                            PartitionedPath(fileStatus, configuration, partitions, Option(rewritten))
+                          )
+                        )
+                      )
+                }
+          }
+        case Empty =>
           Stream.empty
       }
       .handleErrorWith(err =>

--- a/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/rotatingWriter.scala
+++ b/fs2/src/main/scala/com/github/mjakubowski84/parquet4s/parquet/rotatingWriter.scala
@@ -537,7 +537,7 @@ object rotatingWriter {
       prewriteTransformation: T => Stream[F, W],
       postWriteHandlerOpt: Option[PostWriteHandler[F, T]],
       options: ParquetWriter.Options
-  )(implicit F: Async[F]): Pipe[F, T, T] = // TODO check if we still need Async or can we go with Concurrent
+  )(implicit F: Async[F]): Pipe[F, T, T] =
     in =>
       for {
         schema                  <- Stream.eval(schemaF)

--- a/site/src/main/resources/docs/data/menu.yml
+++ b/site/src/main/resources/docs/data/menu.yml
@@ -39,7 +39,7 @@ options:
     url: docs/migration
 
   - title: (Experimental) ETL
-    url: docs/experimental
+    url: docs/etl
 
   - title: (Experimental) Protobuf
     url: docs/protobuf

--- a/site/src/main/resources/docs/docs/filtering.md
+++ b/site/src/main/resources/docs/docs/filtering.md
@@ -27,7 +27,7 @@ You can construct filter predicates using `===`, `!==`, `>`, `>=`, `<`, `<=`, `i
 
 For custom filtering by a column of type `T` implement `UDP[T]` trait and use `udp` operator.
 
-```scala
+```scala mdoc:compile-only
 import com.github.mjakubowski84.parquet4s.{Col, FilterStatistics, ParquetReader, Path, UDP}
 
 case class MyRecord(int: Int)
@@ -59,4 +59,20 @@ ParquetReader
   .as[MyRecord]
   .filter(Col("int").udp(IntDividesBy10))
   .read(Path("my_ints.parquet"))
+```
+
+## Record filter \[experimental\]
+
+`RecordFilter` is an alternative to filter predicates. It allows to filter records based on record index, that is an ordinal of a record in the file.
+
+```scala mdoc:compile-only
+import com.github.mjakubowski84.parquet4s.{ParquetReader, Path, RecordFilter}
+
+case class User(id: Long, email: String, visits: Long)
+
+// skips first 10 users
+ParquetReader
+  .as[User]
+  .filter(RecordFilter(index => index >= 10))
+  .read(Path("file.parquet"))
 ```

--- a/site/src/main/resources/docs/docs/protobuf.md
+++ b/site/src/main/resources/docs/docs/protobuf.md
@@ -31,7 +31,7 @@ val path: Path = ??? // path to write to / to read from
 ParquetWriter.of[GeneratedProtobufData].writeAndClose(path.append("data.parquet"), data)
 
 // read
-Using(ParquetReader.as[GeneratedProtobufData].read(path))(_.foreach(println))
+Using.resource(ParquetReader.as[GeneratedProtobufData].read(path))(_.foreach(println))
 ```
 
 Please follow the [examples](https://github.com/mjakubowski84/parquet4s/tree/master/examples/src/main/scala/com/github/mjakubowski84/parquet4s/scalapb) to learn more.


### PR DESCRIPTION
1. Introduces experimental `RecordFilter` which allows filtering Parquet records based on their index in the file.
2. Series of improvements in a listing partitioned directory. The most prominent change is an eager filtering of the partition directory during the traversal of the directory tree. Thanks to that we can avoid redundant listings of directories wich do not match the filter.