### PR TITLE
feat(akkaPekko): Retry mechanism for ParquetPartitioningFlow

### DIFF
--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
@@ -69,6 +69,11 @@ object ParquetWriter {
     * Parquet</a> to understand what every configuration entry is responsible for. <br> <b>NOTE!</b> Please be careful
     * when using OVERWRITE mode. All data at given path (either file or directory) are deleted before writing in the
     * OVERWRITE mode. <br> Apart from options specific for Parquet file format there are some other:
+    * @param retryEnabled
+    *   can be used to programmatically enable or disable the retry mechanism for the writer in case of an exception
+    *   during writing, it is disabled by default
+    * @param maxRetries
+    *   can be used to programmatically set the amount of max retries for the retry mechanism, it is set to 3 by default
     * @param hadoopConf
     *   can be used to programmatically set Hadoop's [[org.apache.hadoop.conf.Configuration]]
     * @param timeZone
@@ -83,6 +88,8 @@ object ParquetWriter {
       pageSize: Int                              = HadoopParquetWriter.DEFAULT_PAGE_SIZE,
       rowGroupSize: Long                         = HadoopParquetWriter.DEFAULT_BLOCK_SIZE,
       validationEnabled: Boolean                 = HadoopParquetWriter.DEFAULT_IS_VALIDATING_ENABLED,
+      retryEnabled: Boolean                      = false,
+      maxRetries: Int                            = 3,
       hadoopConf: Configuration                  = new Configuration(),
       timeZone: TimeZone                         = TimeZone.getDefault
   ) {


### PR DESCRIPTION
Implementation for the issue #351

I had to add that ClassTag stuff because sbt was complaining about type erasure on the match [here](https://github.com/mjakubowski84/parquet4s/pull/350/files#diff-1a01f20cd6d3cace915f9ae2b24ea5387cc68a30723f7a449bb2618dd0b0b703R393)