### PR TITLE
Issue-366: bumped parquetVersion to next minor (1.14.3 -> 1.14.4)

### DIFF
--- a/project/DependecyVersions.scala
+++ b/project/DependecyVersions.scala
@@ -1,5 +1,5 @@
 object DependecyVersions {
-  val parquetVersion               = "1.14.3"
+  val parquetVersion               = "1.14.4"
   val shapelessVersion             = "2.3.12"
   val sparkVersion                 = "3.5.3"
   val hadoopVersion                = "3.3.6"


### PR DESCRIPTION
org.apache.parquet:parquet-hadoop version 1.14.3 contains an issue wit path parsing in `ParquetWriter` on Windows where it adds `file:/` to the path (cfr. https://github.com/apache/parquet-java/issues/3029), which is fixed in 1.14.4. 