### PR TITLE
Provide native codec for Instant

### DIFF
--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ValueCodecs.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ValueCodecs.scala
@@ -191,6 +191,21 @@ private[parquet4s] object TimeValueCodecs {
         val nanos   = buf.getInt.toLong
 
         Instant.ofEpochSecond(seconds, nanos)
+
+      case DateTimeValue(value, TimestampFormat.Int64Millis) =>
+        Instant.ofEpochMilli(value)
+
+      case DateTimeValue(value, TimestampFormat.Int64Micros) =>
+        val seconds = value / MicrosPerSecond
+        val micros  = value % MicrosPerSecond
+        val nanos   = micros * NanosPerMicro
+        Instant.ofEpochSecond(seconds, nanos)
+
+      case DateTimeValue(value, TimestampFormat.Int64Nanos) =>
+        val seconds = value / NanosPerSecond
+        val nanos   = value % NanosPerSecond
+        Instant.ofEpochSecond(seconds, nanos)
+
     }
 
   def encodeLocalDateTime(data: LocalDateTime, timeZone: TimeZone): Value = BinaryValue {


### PR DESCRIPTION
`TimeValueEncoders.instantEncoder` uses `TimeValueCodecs.encodeLocalDateTime` under the hood, making it depend on a configured `TimeZone`. The main idea to use `Instant` is to _not_ depend on a configured `TimeZone`.

This PR provides a native codec for `Instant`. `TimeValueCodecs.encodeLocalDateTime` _could_ delegate to `TimeValueEncoders.instantEncoder` now, but that's not part of this PR.

**Note:** This change would make data written before unreadable, since it changes the on disc format for `Instant`.